### PR TITLE
Issue #32 - Adding libopencv-dev for compat with Ubuntu 14.04 64 bit

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -115,7 +115,7 @@ sudo apt-get install --assume-yes --install-recommends \
   libjpeg-dev libboost1.48-all-dev libgsl0-dev libx11-dev libxext-dev liblapack-dev \
   libeigen3-dev libflann-dev libvtk5-dev libqhull-dev libusb-1.0-0-dev\
   libzip-dev \
-  libcv-dev libcvaux-dev \
+  libcv-dev libcvaux-dev libopencv-dev \
   > "$TOOLS_LOG_PATH/apt-get_install.log" 2>&1
 
 


### PR DESCRIPTION
Tested and verified this on Ubuntu 14.04 64 bit. @smathermather please verify on Ubuntu 12.04
