### PR TITLE
Update ccd_defs.pl

### DIFF
--- a/ccd_defs.pl
+++ b/ccd_defs.pl
@@ -295,4 +295,8 @@
      "SONY DSC-W80"                             => 5.75,   # 1/2.5"
      "SONY DSC-HX5V"                            => 6.104,  # 1/2.4"
      "SONY NEX-7"                               => 23.5, # APS-C" 
+     "SONY A7"                                  => 35.9, # Full-frame
+     "SONY A7R"                                 => 35.9, # Full-frame
+
+     
 );


### PR DESCRIPTION
Updating with 2 Sony Alpha series, the A7 (24mpixels full frame)  and A7R  (36mpixels full frame) - Two fantastic cameras for UAVs.
