### PR TITLE
Update to JSON ccd_defs to include the Virb

### DIFF
--- a/ccd_defs.json
+++ b/ccd_defs.json
@@ -297,5 +297,6 @@
   "NIKON COOLPIX P7700": 7.44,
   "Canon Canon PowerShot G12": 7.44,
   "Apple iPhone 5s": 8.46,
-  "SONY ILCE-7S": 35.8
+  "SONY ILCE-7S": 35.8,
+  "Garmin VIRB":6.17
 }


### PR DESCRIPTION
Garmin Virb added to CCD defs at 6.17 mm
a great low-cost sensor.
