### PR TITLE
ODM: installation improvements

### DIFF
--- a/convert_vlsift_to_lowesift.pl
+++ b/convert_vlsift_to_lowesift.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/env perl
 
 $filename_base	= $ARGV[0];
                            

--- a/install.sh
+++ b/install.sh
@@ -134,7 +134,7 @@ if [ "$CLEAN_BUILD_DIR" -ne 0 ] ; then echo " * Will clean install dir first" ; 
 
 echo " * Installing to $TOOLS_PATH"
 # limit make to number of cpus
-MAKE='make -j '$(($(cat /proc/cpuinfo | grep processor | wc -l) - 2))
+MAKE='make -j '$(cat /proc/cpuinfo | grep processor | wc -l)
 
 ## paths for the tools
 TOOLS_BIN_PATH="$TOOLS_PATH/bin"

--- a/install.sh
+++ b/install.sh
@@ -542,6 +542,8 @@ pushd "$TOOLS_PATH"
 do_install 'bin/*' bin
 do_install 'lib/*' lib
 do_install ../run.pl bin
+do_install ../convert_vlsift_to_lowesift.pl bin
+do_install ../ccd_defs.json lib 644
 
 #nstall -o $(id -u) -g $(id -g) -m 755 -C -t "$DEST_PATH/$src" 
 #ldconfig -v | tee "$TOOLS_LOG_PATH/ldconfig.log"

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,11 @@ if [ -n "${DEBUG}" ]
 then
     set -h
     set -x
+    set -u
+    set -e
+
 fi;
+
 # default flag values
 CLEAN_BUILD_DIR=0
 INSTALL_PACKAGES=0
@@ -15,7 +19,6 @@ DEST_PATH='/usr/local'
 GETOPTS="d:l:ci"
 
 function die(){
-    set -e
     echo "${1}"
     exit 1
 }
@@ -107,9 +110,6 @@ if [ "$INSTALL_PACKAGES" -ne 0 ] ; then echo " * Will install packages" ; fi;
 if [ "$CLEAN_BUILD_DIR" -ne 0 ] ; then echo " * Will clean install dir first" ; fi;
 
 echo " * Installing to $TOOLS_PATH"
-set -o nounset
-set -o errexit
-
 # limit make to number of cpus
 MAKE='make -j '$(($(cat /proc/cpuinfo | grep processor | wc -l) - 2))
 

--- a/patched_files/src/bundler/src/Makefile
+++ b/patched_files/src/bundler/src/Makefile
@@ -24,7 +24,7 @@ endif
 INCLUDE_PATH=-I../lib/imagelib -I../lib/sfm-driver -I../lib/matrix	\
 	-I../lib/5point -I../lib/sba-1.5 -I../lib/ann_1.1_char/include
 
-LIB_PATH=-L../lib -L../lib/ann_1.1_char/lib
+LIB_PATH=-L../lib -L../lib/ann_1.1_char/lib -L/usr/lib
 
 CPPFLAGS=$(OPTFLAGS) $(OTHERFLAGS) $(INCLUDE_PATH) $(DEFINES)
 
@@ -37,8 +37,10 @@ BUNDLER_OBJS=BaseApp.o BundlerApp.o keys.o Register.o Epipolar.o	\
 	BundleIO.o ProcessBundle.o BundleTwo.o Decompose.o		\
 	RelativePose.o Distortion.o TwoFrameModel.o LoadJPEG.o
 
-BUNDLER_LIBS=-limage -lsfmdrv -lsba.v1.5 -lmatrix -lz -llapack -lblas \
-	-lcblas -lminpack -lm -l5point -ljpeg -lANN_char -lgfortran
+LAPACK_LIBS=$(shell pkg-config lapack --libs) $(shell pkg-config cblas --libs)
+
+BUNDLER_LIBS=-limage -lsfmdrv -lsba.v1.5 -lmatrix -lz $(LAPACK_LIBS) \
+	-lm -l5point -ljpeg -lANN_char -lgfortran -lminpack
 
 
 all: $(BUNDLER) $(KEYMATCHFULL) $(KEYMATCH) $(BUNDLE2PMVS) $(BUNDLE2VIS) $(RADIALUNDISTORT)
@@ -63,7 +65,7 @@ $(KEYMATCH): KeyMatch.o keys2a.o
 
 $(BUNDLE2PMVS): Bundle2PMVS.o LoadJPEG.o
 	$(CXX) -o $@ $(CPPFLAGS) $(LIB_PATH) Bundle2PMVS.o LoadJPEG.o \
-		-limage -lmatrix -llapack -lblas -lcblas -lgfortran \
+		-limage -lmatrix $(LAPACK_LIBS) -lgfortran \
 		-lminpack -ljpeg
 	cp $@ ../bin
 
@@ -73,7 +75,7 @@ $(BUNDLE2VIS): Bundle2Vis.o
 
 $(RADIALUNDISTORT): RadialUndistort.o LoadJPEG.o
 	$(CXX) -o $@ $(CPPFLAGS) $(LIB_PATH) $^ \
-		-limage -lmatrix -llapack -lblas -lcblas -lgfortran \
+		-limage -lmatrix $(LAPACK_LIBS) -lgfortran \
 		-lminpack -ljpeg
 	cp $@ ../bin
 

--- a/patched_files/src/cmvs/program/base/numeric/mylapack.cc
+++ b/patched_files/src/cmvs/program/base/numeric/mylapack.cc
@@ -1,0 +1,233 @@
+#include "mylapack.h"
+#include <cstdlib>
+#include <iostream>
+
+extern "C" {
+#include <clapack/clapack.h>
+};
+
+using namespace std;
+
+// Solve Ax = 0.
+// Values contain singular values stored in an increasing order
+void Cmylapack::hlls(const std::vector<std::vector<float> >& A,
+                     std::vector<float>& vec,
+                     std::vector<float>& values) {  
+  char jobu = 'N';    char jobvt = 'S';
+  integer M = (int)A.size();
+  if (M == 0) {
+    cerr << "Error in hlls" << endl;    exit (1);
+  }
+  integer N = (int)A[0].size();
+  
+  float C[M * N];
+  int count = 0;
+  for (int x = 0; x < N; ++x)
+    for (int y = 0; y < M; ++y) {
+      C[count++] = A[y][x];
+    }
+  integer lda = M;
+  float S[M];
+  integer LDU = 1;
+  float VT[N * N];
+  integer LDVT = N;
+  integer lwork = 5 * max(N, M);
+  float work[lwork];
+  integer info;
+  
+  sgesvd_(&jobu, &jobvt, &M, &N, C, &lda, S, NULL, &LDU,
+          VT, &LDVT, work, &lwork, &info);
+
+  vec.resize(N);
+  values.resize(N);
+  for (int i = 0; i < N; ++i) {
+    vec[i] = VT[N * (i + 1) - 1];
+    values[i] = S[N - 1 - i];
+  }  
+}
+
+// Solve Ax = 0.
+// Values contain singular values stored in an increasing order
+void Cmylapack::hlls(const std::vector<std::vector<double> >& A,
+                     std::vector<double>& vec,
+                     std::vector<double>& values) {
+  
+  char jobu = 'N';    char jobvt = 'S';
+  integer M = (int)A.size();
+  if (M == 0) {
+    cerr << "Error in hlls" << endl;    exit (1);
+  }
+  integer N = (int)A[0].size();
+  
+  double C[M * N];
+  int count = 0;
+  for (int x = 0; x < N; ++x)
+    for (int y = 0; y < M; ++y) {
+      C[count++] = A[y][x];
+    }
+  integer lda = M;
+  double S[M];
+  integer LDU = 1;
+  double VT[N * N];
+  integer LDVT = N;
+  integer lwork = 5 * max(N, M);
+  double work[lwork];
+  integer info;
+  
+  dgesvd_(&jobu, &jobvt, &M, &N, C, &lda, S, NULL, &LDU,
+          VT, &LDVT, work, &lwork, &info);
+
+  vec.resize(N);
+  values.resize(N);
+  for (int i = 0; i < N; ++i) {
+    vec[i] = VT[N * (i + 1) - 1];
+    values[i] = S[N - 1 - i];
+  }  
+}
+
+void Cmylapack::lls(const std::vector<std::vector<float> >& A,
+                    const std::vector<float>& b,
+                    std::vector<float>& ans) {
+  char trans = 'N';
+  integer m = (int)A.size();
+  integer n = (int)A[0].size();
+  integer nrhs = 1;
+  vector<float> a;
+  a.resize(m * n);
+
+  int count = 0;
+  for (int x = 0; x < n; ++x)
+    for (int y = 0; y < m; ++y)
+      a[count++] = A[y][x];
+  integer lda = m;
+  vector<float> b2;
+  b2.resize(m);
+  for (int i = 0; i < m; ++i)
+    b2[i] = b[i];
+  
+  integer ldb = m;
+  integer lwork = n + m;
+  vector<float> work;
+  work.resize(lwork);
+  integer info;
+  sgels_(&trans, &m, &n, &nrhs, &a[0], &lda, &b2[0], &ldb, &work[0],
+         &lwork, &info);
+
+  ans.resize(n);
+  for (int i = 0; i < n; ++i)
+    ans[i] = b2[i];
+}
+
+void Cmylapack::lls(const std::vector<std::vector<double> >& A,
+                    const std::vector<double>& b,
+                    std::vector<double>& ans) {
+  char trans = 'N';
+  integer m = (int)A.size();
+  integer n = (int)A[0].size();
+  integer nrhs = 1;
+  vector<double> a;
+  a.resize(m * n);
+
+  int count = 0;
+  for (int x = 0; x < n; ++x)
+    for (int y = 0; y < m; ++y)
+      a[count++] = A[y][x];
+  integer lda = m;
+  vector<double> b2;
+  b2.resize(m);
+  for (int i = 0; i < m; ++i)
+    b2[i] = b[i];
+  
+  integer ldb = m;
+  integer lwork = n + m;
+  vector<double> work;
+  work.resize(lwork);
+  integer info;
+  dgels_(&trans, &m, &n, &nrhs, &a[0], &lda, &b2[0], &ldb, &work[0],
+         &lwork, &info);
+  
+  ans.resize(n);
+  for (int i = 0; i < n; ++i)
+    ans[i] = b2[i];
+}
+
+void Cmylapack::lls(std::vector<float>& A,
+                    std::vector<float>& b,
+                    integer width, integer height) {
+  char trans = 'N';
+  integer nrhs = 1;
+  integer lwork = width * height;
+  integer info;
+  vector<float> work(width * height);
+  
+  sgels_(&trans, &width, &height, &nrhs, &A[0], &width, &b[0], &width, &work[0],
+         &lwork, &info);
+}
+
+void Cmylapack::lls(std::vector<double>& A,
+                    std::vector<double>& b,
+                    integer width, integer height) {
+  char trans = 'N';
+  integer nrhs = 1;
+  integer lwork = width * height;
+  integer info;
+  vector<double> work(width * height);
+  
+  dgels_(&trans, &width, &height, &nrhs, &A[0], &width, &b[0], &width, &work[0],
+         &lwork, &info);
+}
+
+// SVD
+void Cmylapack::svd(const std::vector<std::vector<float> >& A,
+                    std::vector<std::vector<float> >& U,
+                    std::vector<std::vector<float> >& VT,
+                    std::vector<float>& S) {
+  char jobu = 'A';    char jobvt = 'A';
+  integer M = (int)A.size();
+  if (M == 0) {
+    cerr << "Error in hlls" << endl;    exit (1);
+  }
+  integer N = (int)A[0].size();
+  
+  float C[M * N];
+  int count = 0;
+  for (int x = 0; x < N; ++x)
+    for (int y = 0; y < M; ++y) {
+      C[count++] = A[y][x];
+    }
+  const integer minMN = min(M, N);
+  integer lda = M;
+  float S2[minMN];
+  float U2[M * M];
+  integer LDU = M;
+  float VT2[N * N];
+  integer LDVT = N;
+  integer lwork = 5 * max(N, M);
+  float work[lwork];
+  integer info;
+  
+  sgesvd_(&jobu, &jobvt, &M, &N, C, &lda, S2, U2, &LDU,
+          VT2, &LDVT, work, &lwork, &info);
+
+  U.resize(M);
+  for (int y = 0; y < M; ++y)
+    U[y].resize(M);
+  
+  VT.resize(N);
+  for (int y = 0; y < N; ++y)
+    VT[y].resize(N);
+  
+  count = 0;
+  for (int x = 0; x < M; ++x)
+    for (int y = 0; y < M; ++y)
+      U[y][x] = U2[count++];
+  
+  count = 0;
+  for (int x = 0; x < N; ++x)
+    for (int y = 0; y < N; ++y)
+      VT[y][x] = VT2[count++];
+
+  S.resize(minMN);
+  for (int i = 0; i < minMN; ++i)
+    S[i] = S2[i];
+}

--- a/patched_files/src/cmvs/program/base/numeric/mylapack.h
+++ b/patched_files/src/cmvs/program/base/numeric/mylapack.h
@@ -1,0 +1,46 @@
+#ifndef NUMERIC_MYLAPACK_H
+#define NUMERIC_MYLAPACK_H
+
+#include <vector>
+
+class Cmylapack {
+ public:
+
+
+  // Solve Ax = 0.
+  // Values contain singular values stored in an increasing order
+  static void hlls(const std::vector<std::vector<float> >& A,
+                   std::vector<float>& vec,
+                   std::vector<float>& values);
+
+  static void hlls(const std::vector<std::vector<double> >& A,
+                   std::vector<double>& vec,
+                   std::vector<double>& values);
+  
+  // Solve Ax = b
+  static void lls(const std::vector<std::vector<float> >& A,
+                  const std::vector<float>& b,
+                  std::vector<float>& x);
+  
+  static void lls(const std::vector<std::vector<double> >& A,
+                  const std::vector<double>& b,
+                  std::vector<double>& x);
+
+  static void lls(std::vector<float>& A,
+                  std::vector<float>& b,
+                  int width, int height);
+  
+  static void lls(std::vector<double>& A,
+                  std::vector<double>& b,
+                  int width, int height);
+
+  // SVD
+  // A = U Sigma V^T
+  static void svd(const std::vector<std::vector<float> >& A,
+                  std::vector<std::vector<float> >& U,
+                  std::vector<std::vector<float> >& VT,
+                  std::vector<float>& S);
+  
+};
+
+#endif // NUMERIC_MYLAPACK_H

--- a/patched_files/src/cmvs/program/main/Makefile
+++ b/patched_files/src/cmvs/program/main/Makefile
@@ -1,0 +1,85 @@
+######################################################################
+#
+# The following 2 commands to compile pmvs2.
+# > make depend
+# > make
+#
+######################################################################
+CXX = g++
+
+#Your INCLUDE path (e.g., -I/usr/include)
+YOUR_INCLUDE_PATH =-I/usr/include -I/usr/local/include -I/home/cezio/Projects/e38/opendronemap/repo/dest/include
+
+#Your metis directory (contains header files under graclus1.2/metisLib/)
+YOUR_INCLUDE_METIS_PATH = -I/home/cezio/Projects/e38/opendronemap/repo/dest/include/metisLib/
+
+#Your LDLIBRARY path (e.g., -L/usr/lib)
+YOUR_LDLIB_PATH = -L/usr/lib -L/usr/local/lib -L/home/cezio/Projects/e38/opendronemap/repo/dest/lib
+
+######################################################################
+CXXFLAGS_PMVS = -O2 -Wall -Wno-deprecated ${YOUR_INCLUDE_PATH}
+
+CXXFLAGS_CMVS = -O2 -Wall -Wno-deprecated -DNUMBITS=64 \
+		${YOUR_INCLUDE_PATH} ${YOUR_INCLUDE_METIS_PATH} \
+    -fopenmp -DNUMBITS=64 ${OPENMP_FLAG}
+
+
+LDFLAGS_PMVS = ${YOUR_LDLIB_PATH} -lXext -lX11 -ljpeg -lm -lpthread \
+		-lclapack -lgsl -lgslcblas
+
+LDFLAGS_CMVS = ${YOUR_LDLIB_PATH} -lXext -lX11 -ljpeg -lm -lpthread \
+		-lclapack -fopenmp -lmultilevel -lmetis -lm
+
+######################################################################
+BASE_IMAGE = camera.o image.o photo.o photoSetS.o
+BASE_PMVS = detectFeatures.o detector.o dog.o expand.o filter.o \
+	findMatch.o harris.o optim.o option.o patch.o patchOrganizerS.o \
+	point.o seed.o
+BASE_NUMERIC = mylapack.o
+BASE_CMVS = bundle.o graclus.o
+
+######################################################################
+all: pmvs2 cmvs genOption
+
+
+pmvs2: pmvs2.o ${BASE_IMAGE} ${BASE_PMVS} ${BASE_NUMERIC}
+	${CXX} ${LDFLAGS_PMVS} -o $@ $^ ${LDFLAGS_PMVS}
+
+cmvs: cmvs.o patch.o ${BASE_IMAGE} ${BASE_CMVS}
+	${CXX} ${LDFLAGS_CMVS} -o $@ $^ ${LDFLAGS_CMVS}
+
+genOption: genOption.cc
+	${CXX} -o $@ $^
+
+
+pmvs2.o : pmvs2.cc
+	$(CXX) -c $(CXXFLAGS_PMVS) $<
+
+cmvs.o: cmvs.cc
+	$(CXX) -c $(CXXFLAGS_CMVS) $<
+
+%.o : ../base/pmvs/%.cc
+	$(CXX) -c $(CXXFLAGS_PMVS) $<
+
+%.o : ../base/image/%.cc
+	$(CXX) -c $(CXXFLAGS_PMVS) $<
+
+%.o : ../base/numeric/%.cc
+	$(CXX) -c $(CXXFLAGS_PMVS) $<
+
+%.o : ../base/cmvs/%.cc
+	$(CXX) -c $(CXXFLAGS_CMVS) $<
+
+######################################################################
+# general commands
+clean:
+	/bin/rm -f core core.* *.o ${TARGET}
+
+depend:
+	rm -f Dependencies
+	for SOURCEFILE in `ls *.cc ../base/*/*.cc ../base/*/*.c ../base/*/*.C ../base/*/*.f`; do \
+	  echo $$SOURCEFILE; \
+	  $(CXX) -MM $(CXXFLAGS) $$SOURCEFILE >> Dependencies; \
+	done
+
+-include Dependencies

--- a/run.pl
+++ b/run.pl
@@ -563,7 +563,7 @@ sub getKeypoints {
             } else {
 				unless (-e "$jobOptions{jobDir}/$fileObject->{base}.key.bin") {
 	                $vlsiftJobs    .= "echo -n \"$c/$objectStats{good} - \" && convert -format pgm \"$fileObject->{step_0_resizedImage}\" \"$fileObject->{step_1_pgmFile}\"";
-	                $vlsiftJobs    .= " && \"vlsift\" \"$fileObject->{step_1_pgmFile}\" -o \"$fileObject->{step_1_keyFile}.sift\" > /dev/null && perl \"convert_vlsift_to_lowesift.pl\" \"$jobOptions{jobDir}/$fileObject->{base}\"";
+	                $vlsiftJobs    .= " && \"vlsift\" \"$fileObject->{step_1_pgmFile}\" -o \"$fileObject->{step_1_keyFile}.sift\" > /dev/null && \"convert_vlsift_to_lowesift.pl\" \"$jobOptions{jobDir}/$fileObject->{base}\"";
 	                $vlsiftJobs    .= " && gzip -f \"$fileObject->{step_1_keyFile}\"";
 	                $vlsiftJobs    .= " && rm -f \"$fileObject->{step_1_pgmFile}\"";
 	                $vlsiftJobs    .= " && rm -f \"$fileObject->{step_1_keyFile}.sift\"\n";

--- a/run.pl
+++ b/run.pl
@@ -28,20 +28,18 @@ if(!File::Spec->file_name_is_absolute($BIN_PATH_REL)){
 	$BIN_PATH_ABS = File::Spec->rel2abs($BIN_PATH_REL);
 }
 
-$BIN_PATH = $BIN_PATH_ABS."/bin";
-$LIB_PATH = $BIN_PATH_ABS."/lib";
+$LIB_PATH = File::Spec->rel2abs(join "/", $BIN_PATH_ABS, "..", "lib");
 
 ## add ODM bin path to $PATH
-$ENV{PATH} = join ":", $ENV{PATH}, $BIN_PATH;
+$ENV{PATH} = join ":", $ENV{PATH}, $BIN_ABS_PATH;
 
 ## add this library path to avoid dynlinking errors in tools
 $ENV{LD_LIBRARY_PATH} = join ":", $ENV{LD_LIBRARY_PATH}, $LIB_PATH;
 
 
-
 sub getCcdWidths{
     local $/;
-    my $ccdPath = "$BIN_PATH_ABS/ccd_defs.json";
+    my $ccdPath = "$LIB_PATH/ccd_defs.json";
     open( my $fh, '<', $ccdPath);
 
     my $ccdWidths = decode_json(<$fh>);
@@ -565,7 +563,7 @@ sub getKeypoints {
             } else {
 				unless (-e "$jobOptions{jobDir}/$fileObject->{base}.key.bin") {
 	                $vlsiftJobs    .= "echo -n \"$c/$objectStats{good} - \" && convert -format pgm \"$fileObject->{step_0_resizedImage}\" \"$fileObject->{step_1_pgmFile}\"";
-	                $vlsiftJobs    .= " && \"vlsift\" \"$fileObject->{step_1_pgmFile}\" -o \"$fileObject->{step_1_keyFile}.sift\" > /dev/null && perl \"$BIN_PATH/../convert_vlsift_to_lowesift.pl\" \"$jobOptions{jobDir}/$fileObject->{base}\"";
+	                $vlsiftJobs    .= " && \"vlsift\" \"$fileObject->{step_1_pgmFile}\" -o \"$fileObject->{step_1_keyFile}.sift\" > /dev/null && perl \"$convert_vlsift_to_lowesift.pl\" \"$jobOptions{jobDir}/$fileObject->{base}\"";
 	                $vlsiftJobs    .= " && gzip -f \"$fileObject->{step_1_keyFile}\"";
 	                $vlsiftJobs    .= " && rm -f \"$fileObject->{step_1_pgmFile}\"";
 	                $vlsiftJobs    .= " && rm -f \"$fileObject->{step_1_keyFile}.sift\"\n";

--- a/run.pl
+++ b/run.pl
@@ -29,9 +29,13 @@ if(!File::Spec->file_name_is_absolute($BIN_PATH_REL)){
 }
 
 $BIN_PATH = $BIN_PATH_ABS."/bin";
+$LIB_PATH = $BIN_PATH_ABS."/lib";
 
 ## add ODM bin path to $PATH
-$ENV{PATH}= join ":", $ENV{PATH}, $BIN_PATH;
+$ENV{PATH} = join ":", $ENV{PATH}, $BIN_PATH;
+
+## add this library path to avoid dynlinking errors in tools
+$ENV{LD_LIBRARY_PATH} = join ":", $ENV{LD_LIBRARY_PATH}, $LIB_PATH;
 
 
 

--- a/run.pl
+++ b/run.pl
@@ -563,7 +563,7 @@ sub getKeypoints {
             } else {
 				unless (-e "$jobOptions{jobDir}/$fileObject->{base}.key.bin") {
 	                $vlsiftJobs    .= "echo -n \"$c/$objectStats{good} - \" && convert -format pgm \"$fileObject->{step_0_resizedImage}\" \"$fileObject->{step_1_pgmFile}\"";
-	                $vlsiftJobs    .= " && \"vlsift\" \"$fileObject->{step_1_pgmFile}\" -o \"$fileObject->{step_1_keyFile}.sift\" > /dev/null && perl \"$convert_vlsift_to_lowesift.pl\" \"$jobOptions{jobDir}/$fileObject->{base}\"";
+	                $vlsiftJobs    .= " && \"vlsift\" \"$fileObject->{step_1_pgmFile}\" -o \"$fileObject->{step_1_keyFile}.sift\" > /dev/null && perl \"convert_vlsift_to_lowesift.pl\" \"$jobOptions{jobDir}/$fileObject->{base}\"";
 	                $vlsiftJobs    .= " && gzip -f \"$fileObject->{step_1_keyFile}\"";
 	                $vlsiftJobs    .= " && rm -f \"$fileObject->{step_1_pgmFile}\"";
 	                $vlsiftJobs    .= " && rm -f \"$fileObject->{step_1_keyFile}.sift\"\n";

--- a/run.pl
+++ b/run.pl
@@ -28,6 +28,13 @@ if(!File::Spec->file_name_is_absolute($BIN_PATH_REL)){
 	$BIN_PATH_ABS = File::Spec->rel2abs($BIN_PATH_REL);
 }
 
+$BIN_PATH = $BIN_PATH_ABS."/bin";
+
+## add ODM bin path to $PATH
+$ENV{PATH}= join ":", $ENV{PATH}, $BIN_PATH;
+
+
+
 sub getCcdWidths{
     local $/;
     my $ccdPath = "$BIN_PATH_ABS/ccd_defs.json";
@@ -41,7 +48,7 @@ sub getCcdWidths{
 
 $ccdWidths = getCcdWidths();
 
-$BIN_PATH = $BIN_PATH_ABS."/bin";
+
 
 my %objectStats    = {
     count           => 0,
@@ -547,14 +554,14 @@ sub getKeypoints {
         if($fileObject->{isOk}){
             if($args{"--lowe-sift"}){
                 $vlsiftJobs    .= "echo -n \"$c/$objectStats{good} - \" && convert -format pgm \"$fileObject->{step_0_resizedImage}\" \"$fileObject->{step_1_pgmFile}\"";
-                $vlsiftJobs    .= " && \"$BIN_PATH/sift\" < \"$fileObject->{step_1_pgmFile}\" > \"$fileObject->{step_1_keyFile}\"";
+                $vlsiftJobs    .= " && \"sift\" < \"$fileObject->{step_1_pgmFile}\" > \"$fileObject->{step_1_keyFile}\"";
                 $vlsiftJobs    .= " && gzip -f \"$fileObject->{step_1_keyFile}\"";
                 $vlsiftJobs    .= " && rm -f \"$fileObject->{step_1_pgmFile}\"";
                 $vlsiftJobs    .= " && rm -f \"$fileObject->{step_1_keyFile}.sift\"\n";
             } else {
 				unless (-e "$jobOptions{jobDir}/$fileObject->{base}.key.bin") {
 	                $vlsiftJobs    .= "echo -n \"$c/$objectStats{good} - \" && convert -format pgm \"$fileObject->{step_0_resizedImage}\" \"$fileObject->{step_1_pgmFile}\"";
-	                $vlsiftJobs    .= " && \"$BIN_PATH/vlsift\" \"$fileObject->{step_1_pgmFile}\" -o \"$fileObject->{step_1_keyFile}.sift\" > /dev/null && perl \"$BIN_PATH/../convert_vlsift_to_lowesift.pl\" \"$jobOptions{jobDir}/$fileObject->{base}\"";
+	                $vlsiftJobs    .= " && \"vlsift\" \"$fileObject->{step_1_pgmFile}\" -o \"$fileObject->{step_1_keyFile}.sift\" > /dev/null && perl \"$BIN_PATH/../convert_vlsift_to_lowesift.pl\" \"$jobOptions{jobDir}/$fileObject->{base}\"";
 	                $vlsiftJobs    .= " && gzip -f \"$fileObject->{step_1_keyFile}\"";
 	                $vlsiftJobs    .= " && rm -f \"$fileObject->{step_1_pgmFile}\"";
 	                $vlsiftJobs    .= " && rm -f \"$fileObject->{step_1_keyFile}.sift\"\n";
@@ -569,7 +576,7 @@ sub getKeypoints {
     print SIFT_DEST $vlsiftJobs;
     close(SIFT_DEST);
     
-    run("\"$BIN_PATH/parallel\" --halt-on-error 1 -j+0 < \"$jobOptions{step_1_vlsift}\"");
+    run("\"parallel\" --halt-on-error 1 -j+0 < \"$jobOptions{step_1_vlsift}\"");
     
     if($args{"--end-with"} ne "getKeypoints"){
         match();
@@ -595,7 +602,7 @@ sub match {
 			unless (-e "$jobOptions{step_2_matches_dir}/$i-$j.txt"){ 
 				
 			   
-				$matchesJobs        .=  "echo -n \".\" && touch \"$jobOptions{step_2_matches_dir}/$i-$j.txt\" && \"$BIN_PATH/KeyMatch\" \"@objects[$i]->{step_1_keyFile}\" \"@objects[$j]->{step_1_keyFile}\" \"$jobOptions{step_2_matches_dir}/$i-$j.txt\" $args{'--matcher-ratio'} $args{'--matcher-threshold'}\n";
+				$matchesJobs        .=  "echo -n \".\" && touch \"$jobOptions{step_2_matches_dir}/$i-$j.txt\" && \"KeyMatch\" \"@objects[$i]->{step_1_keyFile}\" \"@objects[$j]->{step_1_keyFile}\" \"$jobOptions{step_2_matches_dir}/$i-$j.txt\" $args{'--matcher-ratio'} $args{'--matcher-threshold'}\n";
 			}
 		}
 	}
@@ -604,7 +611,7 @@ sub match {
     print MATCH_DEST $matchesJobs;
     close(MATCH_DEST);
 	
-    run("\"$BIN_PATH/parallel\" --halt-on-error 1 -j+0 < \"$jobOptions{step_2_macthes_jobs}\"");
+    run("\"parallel\" --halt-on-error 1 -j+0 < \"$jobOptions{step_2_macthes_jobs}\"");
 	
 	run("rm -f \"$jobOptions{step_2_matches}\"");
 	
@@ -630,7 +637,7 @@ sub match {
     print MATCH_DEST $filesList;
     close(MATCH_DEST);
     
- #   run("\"$BIN_PATH/KeyMatchFull\" \"$jobOptions{step_2_filelist}\" \"$jobOptions{step_2_matches}\"    ");
+ #   run("\"KeyMatchFull\" \"$jobOptions{step_2_filelist}\" \"$jobOptions{step_2_matches}\"    ");
     
     if($args{"--end-with"} ne "match"){
         bundler();
@@ -679,9 +686,9 @@ sub bundler {
     print BUNDLER_DEST $filesList;
     close(BUNDLER_DEST);
     
-    run("\"$BIN_PATH/bundler\" \"$jobOptions{step_3_filelist}\" --options_file \"$jobOptions{step_3_bundlerOptions}\" > bundle/out");
-    run("\"$BIN_PATH/Bundle2PMVS\" \"$jobOptions{step_3_filelist}\" bundle/bundle.out");
-    run("\"$BIN_PATH/RadialUndistort\" \"$jobOptions{step_3_filelist}\" bundle/bundle.out pmvs");
+    run("\"bundler\" \"$jobOptions{step_3_filelist}\" --options_file \"$jobOptions{step_3_bundlerOptions}\" > bundle/out");
+    run("\"Bundle2PMVS\" \"$jobOptions{step_3_filelist}\" bundle/bundle.out");
+    run("\"RadialUndistort\" \"$jobOptions{step_3_filelist}\" bundle/bundle.out pmvs");
     
     $i = 0;
     
@@ -698,7 +705,7 @@ sub bundler {
         }
     }
     
-    system("\"$BIN_PATH/Bundle2Vis\" pmvs/bundle.rd.out pmvs/vis.dat");
+    system("\"Bundle2Vis\" pmvs/bundle.rd.out pmvs/vis.dat");
     
     if($args{"--end-with"} ne "bundler"){
         cmvs();
@@ -712,8 +719,8 @@ sub cmvs {
 
     chdir($jobOptions{jobDir});
     
-    run("\"$BIN_PATH/cmvs\" pmvs/ $args{'--cmvs-maxImages'} $CORES");
-    run("\"$BIN_PATH/genOption\" pmvs/ $args{'--pmvs-level'} $args{'--pmvs-csize'} $args{'--pmvs-threshold'} $args{'--pmvs-wsize'} $args{'--pmvs-minImageNum'} $CORES");
+    run("\"cmvs\" pmvs/ $args{'--cmvs-maxImages'} $CORES");
+    run("\"genOption\" pmvs/ $args{'--pmvs-level'} $args{'--pmvs-csize'} $args{'--pmvs-threshold'} $args{'--pmvs-wsize'} $args{'--pmvs-minImageNum'} $CORES");
     
     if($args{"--end-with"} ne "cmvs"){
         pmvs();
@@ -727,7 +734,7 @@ sub pmvs {
 
     chdir($jobOptions{jobDir});
     
-    run("\"$BIN_PATH/pmvs2\" pmvs/ option-0000");
+    run("\"pmvs2\" pmvs/ option-0000");
     
     system("cp -Rf \"$jobOptions{jobDir}/pmvs/models\" \"$jobOptions{jobDir}-results\"");
     
@@ -745,7 +752,7 @@ sub odm_meshing {
     mkdir($jobOptions{jobDir}."/odm_meshing");    
 
 
-    run("\"$BIN_PATH/odm_meshing\" -inputFile $jobOptions{jobDir}-results/option-0000.ply -outputFile $jobOptions{jobDir}-results/odm_mesh-0000.ply -logFile $jobOptions{jobDir}/odm_meshing/odm_meshing_log.txt -maxVertexCount $args{'--odm_meshing-maxVertexCount'} -octreeDepth $args{'--odm_meshing-octreeDepth'} -samplesPerNode $args{'--odm_meshing-samplesPerNode'}" );
+    run("\"odm_meshing\" -inputFile $jobOptions{jobDir}-results/option-0000.ply -outputFile $jobOptions{jobDir}-results/odm_mesh-0000.ply -logFile $jobOptions{jobDir}/odm_meshing/odm_meshing_log.txt -maxVertexCount $args{'--odm_meshing-maxVertexCount'} -octreeDepth $args{'--odm_meshing-octreeDepth'} -samplesPerNode $args{'--odm_meshing-samplesPerNode'}" );
     
     if($args{"--end-with"} ne "odm_meshing"){
         odm_texturing();
@@ -762,7 +769,7 @@ sub odm_texturing {
     mkdir("$jobOptions{jobDir}-results/odm_texturing"); 
 
 
-    run("\"$BIN_PATH/odm_texturing\" -bundleFile $jobOptions{jobDir}/pmvs/bundle.rd.out -imagesPath $jobOptions{srcDir}/ -imagesListPath $jobOptions{jobDir}/pmvs/list.rd.txt -inputModelPath $jobOptions{jobDir}-results/odm_mesh-0000.ply -outputFolder $jobOptions{jobDir}-results/odm_texturing/ -textureResolution $args{'--odm_texturing-textureResolution'} -bundleResizedTo $jobOptions{resizeTo} -textureWithSize $args{'--odm_texturing-textureWithSize'} -logFile $jobOptions{jobDir}/odm_texturing/odm_texturing_log.txt" );
+    run("\"odm_texturing\" -bundleFile $jobOptions{jobDir}/pmvs/bundle.rd.out -imagesPath $jobOptions{srcDir}/ -imagesListPath $jobOptions{jobDir}/pmvs/list.rd.txt -inputModelPath $jobOptions{jobDir}-results/odm_mesh-0000.ply -outputFolder $jobOptions{jobDir}-results/odm_texturing/ -textureResolution $args{'--odm_texturing-textureResolution'} -bundleResizedTo $jobOptions{resizeTo} -textureWithSize $args{'--odm_texturing-textureWithSize'} -logFile $jobOptions{jobDir}/odm_texturing/odm_texturing_log.txt" );
     
     if($args{"--end-with"} ne "odm_texturing"){
         odm_georeferencing();
@@ -779,11 +786,11 @@ sub odm_georeferencing {
     mkdir($jobOptions{jobDir}."/odm_georeferencing");
 
     if($args{"--odm_georeferencing-useGcp"} ne "true") {
-        run("\"$BIN_PATH/odm_extract_utm\" -imagesPath $jobOptions{srcDir}/ -imageListFile $jobOptions{jobDir}/pmvs/list.rd.txt -outputCoordFile $jobOptions{jobDir}/odm_georeferencing/coordFile.txt");
+        run("\"odm_extract_utm\" -imagesPath $jobOptions{srcDir}/ -imageListFile $jobOptions{jobDir}/pmvs/list.rd.txt -outputCoordFile $jobOptions{jobDir}/odm_georeferencing/coordFile.txt");
    
-        run("\"$BIN_PATH/odm_georef\" -bundleFile $jobOptions{jobDir}/pmvs/bundle.rd.out -coordFile $jobOptions{jobDir}/odm_georeferencing/coordFile.txt -inputFile $jobOptions{jobDir}-results/odm_texturing/odm_textured_model.obj -outputFile $jobOptions{jobDir}-results/odm_texturing/odm_textured_model_geo.obj -logFile $jobOptions{jobDir}/odm_georeferencing/odm_georeferencing_log.txt");
+        run("\"odm_georef\" -bundleFile $jobOptions{jobDir}/pmvs/bundle.rd.out -coordFile $jobOptions{jobDir}/odm_georeferencing/coordFile.txt -inputFile $jobOptions{jobDir}-results/odm_texturing/odm_textured_model.obj -outputFile $jobOptions{jobDir}-results/odm_texturing/odm_textured_model_geo.obj -logFile $jobOptions{jobDir}/odm_georeferencing/odm_georeferencing_log.txt");
     } else {
-        run("\"$BIN_PATH/odm_georef\" -bundleFile $jobOptions{jobDir}/pmvs/bundle.rd.out -gcpFile $jobOptions{srcDir}/$args{'--odm_georeferencing-gcpFile'} -imagesPath $jobOptions{srcDir}/ -imagesListPath $jobOptions{jobDir}/pmvs/list.rd.txt -bundleResizedTo $jobOptions{resizeTo} -inputFile $jobOptions{jobDir}-results/odm_texturing/odm_textured_model.obj -outputFile $jobOptions{jobDir}-results/odm_texturing/odm_textured_model_geo.obj -logFile $jobOptions{jobDir}/odm_georeferencing/odm_georeferencing_log.txt");
+        run("\"odm_georef\" -bundleFile $jobOptions{jobDir}/pmvs/bundle.rd.out -gcpFile $jobOptions{srcDir}/$args{'--odm_georeferencing-gcpFile'} -imagesPath $jobOptions{srcDir}/ -imagesListPath $jobOptions{jobDir}/pmvs/list.rd.txt -bundleResizedTo $jobOptions{resizeTo} -inputFile $jobOptions{jobDir}-results/odm_texturing/odm_textured_model.obj -outputFile $jobOptions{jobDir}-results/odm_texturing/odm_textured_model_geo.obj -logFile $jobOptions{jobDir}/odm_georeferencing/odm_georeferencing_log.txt");
 }
     
     if($args{"--end-with"} ne "odm_georeferencing"){
@@ -802,7 +809,7 @@ sub odm_orthophoto {
     mkdir($jobOptions{jobDir}."/odm_orthophoto");
 
 
-    run("\"$BIN_PATH/odm_orthophoto\" -inputFile $jobOptions{jobDir}-results/odm_texturing/odm_textured_model_geo.obj -logFile $jobOptions{jobDir}/odm_orthophoto/odm_orthophoto_log.txt -outputFile $jobOptions{jobDir}-results/odm_orthphoto.png -resolution 20.0");
+    run("\"odm_orthophoto\" -inputFile $jobOptions{jobDir}-results/odm_texturing/odm_textured_model_geo.obj -logFile $jobOptions{jobDir}/odm_orthophoto/odm_orthophoto_log.txt -outputFile $jobOptions{jobDir}-results/odm_orthphoto.png -resolution 20.0");
 
 }
 


### PR DESCRIPTION
This is WiP, contains fixes for #109:
- add options to install.sh script (custom build dir, custom install dir, ability to skip system packages install and cleaning build dir)
- improvements in `install.sh` (parametrize of make call, use headers/libs installed system-wide instead of local copies, updated dependencies, patch for cmvs instead of full source archive)
- adjusting paths in `run.pl`, use of env variables to locate binaries and libraries
- fix broken cmvs `base/numeric/mylapack.h/cc`: signature didn't match header file (https://github.com/OpenDroneMap/OpenDroneMap/pull/110/files#diff-08694398d092944a0fe84fc0b2477895R154 and https://github.com/OpenDroneMap/OpenDroneMap/pull/110/files#diff-08694398d092944a0fe84fc0b2477895R167), removed `<clapack/f2c.h>` include (wrong path, `f2c.h` already included by `clapack.h`)
