### PR TITLE
Add option to zip results

### DIFF
--- a/run.pl
+++ b/run.pl
@@ -367,7 +367,7 @@ sub parseArgs {
         print "\n                       default: 1";
         print "\n                                Number of points per octree node, recommended value: 1.0";
 
-        print "\n  --zip_results: <true|false>";
+        print "\n  --zip-results: <true|false>";
         print "\n        default: true";
         print "\n                 Set to false if you do not want to have gunzipped tarball of the results.";
 
@@ -840,8 +840,12 @@ switch ($args{"--start-with"}) {
     case "odm_orthophoto"      { odm_orthophoto();      }
 }
 
+if($args{"--zip-results"} eq "true") { 
+    print "\nCompressing results - "; now(); print "\n";
+    print "\n";
 
-
+    run("tar -czf $jobOptions{jobDir}-results.tar.gz $jobOptions{jobDir}-results/*");
+}
 
 print "\n";
 print "\n  - done - "; now(); print "\n";

--- a/run.pl
+++ b/run.pl
@@ -843,8 +843,7 @@ switch ($args{"--start-with"}) {
 if($args{"--zip-results"} eq "true") { 
     print "\nCompressing results - "; now(); print "\n";
     print "\n";
-
-    run("tar -czf $jobOptions{jobDir}-results.tar.gz $jobOptions{jobDir}-results/*");
+    run("cd $jobOptions{jobDir}-results/ && tar -czf $jobOptions{jobDir}-results.tar.gz *");
 }
 
 print "\n";

--- a/run.pl
+++ b/run.pl
@@ -105,6 +105,8 @@ sub parseArgs {
 
     $args{"--odm_georeferencing-gcpFile"}	= "gcp_list.txt";
     $args{"--odm_georeferencing-useGcp"}	= "true";
+
+    $args{"--zip-results"}           = "true";
     
     for($i = 0; $i <= $#ARGV; $i++) {
         if($ARGV[$i] =~ /^--[^a-z\-]*/){
@@ -269,6 +271,13 @@ sub parseArgs {
                         die "\n invalid parameter for \"".$ARGV[$i]."\": ".$ARGV[$i+1];
                     }
                 }
+		if($ARGV[$i] eq "--zip-results"){
+                    if($ARGV[$i+1] eq "true" || $ARGV[$i+1] eq "false"){
+                        $args{$ARGV[$i]} = $ARGV[$i+1];
+                    } else {
+                        die "\n invalid parameter for \"".$ARGV[$i]."\": ".$ARGV[$i+1];
+                    }
+                }
             }
         }
     }
@@ -357,6 +366,10 @@ sub parseArgs {
         print "\n  --odm_meshing-samplesPerNode: <float: 1.0 <= x>";
         print "\n                       default: 1";
         print "\n                                Number of points per octree node, recommended value: 1.0";
+
+        print "\n  --zip_results: <true|false>";
+        print "\n        default: true";
+        print "\n                 Set to false if you do not want to have gunzipped tarball of the results.";
 
         exit;
     }
@@ -826,6 +839,9 @@ switch ($args{"--start-with"}) {
     case "odm_georeferencing"  { odm_georeferencing();  }
     case "odm_orthophoto"      { odm_orthophoto();      }
 }
+
+
+
 
 print "\n";
 print "\n  - done - "; now(); print "\n";


### PR DESCRIPTION
using the option "--zip-results true" a tar.gz archive of the reconstruction-with-image-size-{imageSize}-results directory is created. True is the default. 

See [here](https://www.dropbox.com/s/xhczf9z9v48iuxt/reconstruction-with-image-size-2400-results.tar.gz?dl=0) for example of the resulting tarball. 
