### PR TITLE
Added Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:14.04
+MAINTAINER Danilo Bargen <mail@dbrgn.ch>
+
+# Env variables
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install git
+RUN apt-get update \
+    && apt-get install -y git
+
+# Install dependencies
+RUN apt-get install -y --install-recommends \
+        build-essential cmake g++ gcc gFortran perl git autoconf \
+        curl wget \
+        unzip \
+        imagemagick jhead proj-bin libproj-dev\
+        libjpeg-dev libboost-all-dev libgsl0-dev libx11-dev libxext-dev liblapack-dev \
+        libeigen3-dev libflann-dev libvtk5-dev libqhull-dev libusb-1.0-0-dev\
+        libjson-perl \
+        libzip-dev \
+        libswitch-perl \
+        libcv-dev libcvaux-dev libopencv-dev \
+        libgoogle-glog-dev libatlas-base-dev libsuitesparse-dev \
+    && apt-get autoremove \
+    && apt-get clean
+
+# Add users
+RUN useradd -m -U odm
+
+# Prepare directories
+RUN mkdir /code
+WORKDIR /code
+
+# Add repository files
+ADD . /code/
+
+# Update submodules
+RUN git submodule init && git submodule update
+
+# Build OpenDroneMap
+RUN ./install.sh && \
+    chown -R odm:odm /code
+USER odm
+
+# Entry point
+VOLUME ["/images"]
+WORKDIR /images
+ENTRYPOINT ["/code/run.pl"]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ Now that texturing is in the code base, you can access the full textured meshes 
 
 ---
 
+Alternatively, you can also run OpenDroneMap in a Docker container:
+
+    export IMAGES=/absolute/path/to/your/images
+    docker build -t opendronemap:latest .
+    docker run -v $IMAGES:/images opendronemap:latest
+
+To pass in custom parameters to the `run.pl` script, simply pass it as arguments to the `docker run` command.
+
+---
+
 Example data can be found at https://github.com/OpenDroneMap/odm_data
 
 ---


### PR DESCRIPTION
This PR adds a Dockerfile to the repository. With Docker, processing data from Linux or OS X (with boot2docker) becomes much easier:

```
git clone https://github.com/OpenDroneMap/OpenDroneMap/
cd OpenDroneMap
export IMAGES=/absolute/path/to/your/images
docker build -t opendronemap:latest .
docker run -v $IMAGES:/images opendronemap:latest
```

Done, a few hours later the result is located in your images directory :)

This could also be used to simplify processing in the cloud, e.g. on Amazon AWS.

Once this PR is in the codebase, we should set up an [automated build](https://docs.docker.com/docker-hub/builds/) on Dockerhub. Then every push to Github results in a new image being built, making the process above even easier (and quicker, as the image doesn't have to be re-built):

```
export IMAGES=/absolute/path/to/your/images
docker run -v $IMAGES:/images opendronemap/opendronemap:latest
```
