### PR TITLE
Do not change file extension when resizing images

### DIFF
--- a/run.pl
+++ b/run.pl
@@ -497,7 +497,7 @@ sub prepareObjects {
         
     foreach $fileObject (@objects) {
         if($fileObject->{isOk}){
-            $fileObject->{step_0_resizedImage}  = "$jobOptions{jobDir}/$fileObject->{base}.jpg";
+            $fileObject->{step_0_resizedImage}  = "$jobOptions{jobDir}/$fileObject->{src}";
             
             $fileObject->{step_1_pgmFile}       = "$jobOptions{jobDir}/$fileObject->{base}.pgm";
             $fileObject->{step_1_keyFile}       = "$jobOptions{jobDir}/$fileObject->{base}.key";

--- a/run.pl
+++ b/run.pl
@@ -668,7 +668,7 @@ sub bundler {
     foreach $fileObject (@objects) {
         if($fileObject->{isOk}){
             if($fileObject->{isOk}){
-                $filesList        .= sprintf("\./%s.jpg 0 %0.5f\n", $fileObject->{base}, $fileObject->{focalpx});
+                $filesList        .= sprintf("\./%s 0 %0.5f\n", $fileObject->{src}, $fileObject->{focalpx});
             }
         }
     }

--- a/run.py
+++ b/run.py
@@ -606,7 +606,7 @@ def bundler():
 
     for fileObject in objects:
         if fileObject["isOk"]:
-            filesList += "./" + fileObject["base"] + ".jpg 0 {:.5f}\n".format(fileObject["focalpx"])
+            filesList += "./" + fileObject["src"] + " 0 {:.5f}\n".format(fileObject["focalpx"])
 
     filesList = filesList.rstrip('\n')
 

--- a/run.py
+++ b/run.py
@@ -439,7 +439,7 @@ def prepare_objects():
 
     for fileObject in objects:
         if fileObject["isOk"]:
-            fileObject["step_0_resizedImage"] = jobOptions["jobDir"] + "/" + fileObject["base"] + ".jpg"
+            fileObject["step_0_resizedImage"] = jobOptions["jobDir"] + "/" + fileObject["src"]
             fileObject["step_1_pgmFile"] = jobOptions["jobDir"] + "/" + fileObject["base"] + ".pgm"
             fileObject["step_1_keyFile"] = jobOptions["jobDir"] + "/" + fileObject["base"] + ".key"
             fileObject["step_1_gzFile"] = jobOptions["jobDir"] + "/" + fileObject["base"] + ".key.gz"


### PR DESCRIPTION
odm_texture uses the list.txt file created for bundler. The file contains the list of resized images.
odm_texture uses this filenames to get the original images. If the name of the original images and the name of the resized images is not the same, odm_texture does not find the original images.

This was giving problems when the original files had any extension different than "jpg". For example "JPG".
