### PR TITLE
Make compiled OpenCV default for other functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pcl.tar.gz
 ceres-solver.tar.gz
 *.pyc
 pcl.tar.gz
+opencv.zip

--- a/install.sh
+++ b/install.sh
@@ -128,7 +128,6 @@ sudo apt-get install --assume-yes --install-recommends \
   libeigen3-dev libflann-dev libvtk5-dev libqhull-dev libusb-1.0-0-dev\
   libzip-dev \
   libswitch-perl libjson-perl \
-##  libcv-dev libcvaux-dev libopencv-dev \
   gdal-bin \
   exiv2 \
   libgoogle-glog-dev libatlas-base-dev libsuitesparse-dev \

--- a/install.sh
+++ b/install.sh
@@ -128,7 +128,7 @@ sudo apt-get install --assume-yes --install-recommends \
   libeigen3-dev libflann-dev libvtk5-dev libqhull-dev libusb-1.0-0-dev\
   libzip-dev \
   libswitch-perl libjson-perl \
-  libcv-dev libcvaux-dev libopencv-dev \
+##  libcv-dev libcvaux-dev libopencv-dev \
   gdal-bin \
   exiv2 \
   libgoogle-glog-dev libatlas-base-dev libsuitesparse-dev \
@@ -144,7 +144,6 @@ sudo apt-get install --assume-yes --install-recommends \
   libjson-perl \
   libzip-dev \
   libswitch-perl \
-  libcv-dev libcvaux-dev libopencv-dev \
   libgoogle-glog-dev libatlas-base-dev libeigen3-dev libsuitesparse-dev \
   python-dev python-pip libboost-python-dev \
   python-numpy-dev python-scipy python-yaml \
@@ -482,7 +481,7 @@ echo "  > texturing "
 	cd "$ODM_TEXTURING_PATH"
 	
 	echo "    - configuring odm_texturing"
-	cmake . -DPCL_DIR="$TOOLS_LIB_PATH/pcl" > "$TOOLS_LOG_PATH/odm_texturing_1_build.log" 2>&1
+	cmake . -DPCL_DIR="$TOOLS_LIB_PATH/pcl" -DOPENCV_DIR="$TOOLS_PATH/share/OpenCV" > "$TOOLS_LOG_PATH/odm_texturing_1_build.log" 2>&1
 	
 	echo "    - building odm_texturing"
 	make > "$TOOLS_LOG_PATH/odm_texturing_2_build.log" 2>&1
@@ -512,7 +511,7 @@ echo "  > georef "
 	cd "$ODM_GEOREF_PATH"
 	
 	echo "    - configuring odm_georef"
-	cmake . -DPCL_DIR="$TOOLS_LIB_PATH/pcl" > "$TOOLS_LOG_PATH/odm_georef_1_build.log" 2>&1
+	cmake . -DPCL_DIR="$TOOLS_LIB_PATH/pcl" -DOPENCV_DIR="$TOOLS_PATH/share/OpenCV" > "$TOOLS_LOG_PATH/odm_georef_1_build.log" 2>&1
 	
 	echo "    - building odm_georef"
 	make > "$TOOLS_LOG_PATH/odm_georef_2_build.log" 2>&1
@@ -527,7 +526,7 @@ echo "  > orthophoto "
 	cd "$ODM_ORTHOPHOTO_PATH"
 	
 	echo "    - configuring odm_orthophoto"
-	cmake . -DPCL_DIR="$TOOLS_LIB_PATH/pcl" > "$TOOLS_LOG_PATH/odm_orthophoto_1_build.log" 2>&1
+	cmake . -DPCL_DIR="$TOOLS_LIB_PATH/pcl" -DOPENCV_DIR="$TOOLS_PATH/share/OpenCV" > "$TOOLS_LOG_PATH/odm_orthophoto_1_build.log" 2>&1
 	
 	echo "    - building odm_orthophoto"
 	make > "$TOOLS_LOG_PATH/odm_orthophoto_2_build.log" 2>&1

--- a/odm_georef/CMakeLists.txt
+++ b/odm_georef/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.8)
 
 # Set pcl dir to the input spedified with option -DPCL_DIR="path"
 set(PCL_DIR "PCL_DIR-NOTFOUND" CACHE "PCL_DIR" "Path to the pcl installation directory")
+set(OPENCV_DIR "OPENCV_DIR-NOTFOUND" CACHE "OPENCV_DIR" "Path to the opencv installation directory")
 set(PROJ4_INCLUDE_DIR "/usr/include/" CACHE "PROJ4_INCLUDE_DIR" "Path to the proj4 inlcude directory")
 set(PROJ4_LIBRARY "/usr/lib/libproj.so" CACHE "PROJ4_LIBRARY" "Path to the proj4 library directory")
 
@@ -14,7 +15,7 @@ add_definitions(-Wall -Wextra -Wconversion -pedantic)
 find_package(PCL 1.7 HINTS "${PCL_DIR}/share/pcl-1.7")
 
 # Find OpenCV at the default location
-find_package(OpenCV REQUIRED)
+find_package(OpenCV HINTS "${OPENCV_DIR}" REQUIRED)
 
 # Only link with required opencv modules.
 set(OpenCV_LIBS opencv_core opencv_imgproc opencv_highgui)

--- a/odm_orthophoto/CMakeLists.txt
+++ b/odm_orthophoto/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.8)
 
 # Set pcl dir to the input spedified with option -DPCL_DIR="path"
 set(PCL_DIR "PCL_DIR-NOTFOUND" CACHE "PCL_DIR" "Path to the pcl installation directory")
+set(OPENCV_DIR "OPENCV_DIR-NOTFOUND" CACHE "OPENCV_DIR" "Path to the OPENCV installation directory")
 
 # Add compiler options.
 add_definitions(-Wall -Wextra)
@@ -11,7 +12,7 @@ add_definitions(-Wall -Wextra)
 find_package(PCL 1.7 HINTS "${PCL_DIR}/share/pcl-1.7" REQUIRED)
 
 # Find OpenCV at the default location
-find_package(OpenCV REQUIRED)
+find_package(OpenCV HINTS "${OPENCV_DIR}" REQUIRED)
 
 # Only link with required opencv modules.
 set(OpenCV_LIBS opencv_core opencv_imgproc opencv_highgui)

--- a/odm_texturing/CMakeLists.txt
+++ b/odm_texturing/CMakeLists.txt
@@ -4,6 +4,9 @@ cmake_minimum_required(VERSION 2.8)
 # Set pcl dir to the input spedified with option -DPCL_DIR="path"
 set(PCL_DIR "PCL_DIR-NOTFOUND" CACHE "PCL_DIR" "Path to the pcl installation directory")
 
+# Set opencv dir to the input spedified with option -DOPENCV_DIR="path"
+set(OPENCV_DIR "OPENCV_DIR-NOTFOUND" CACHE "OPENCV_DIR" "Path to the opencv installation directory")
+
 # Add compiler options.
 add_definitions(-Wall -Wextra)
 
@@ -11,7 +14,7 @@ add_definitions(-Wall -Wextra)
 find_package(PCL 1.7 HINTS "${PCL_DIR}/share/pcl-1.7" REQUIRED)
 
 # Find OpenCV at the default location
-find_package(OpenCV REQUIRED)
+find_package(OpenCV HINTS "${OPENCV_DIR}" REQUIRED)
 
 # Only link with required opencv modules.
 set(OpenCV_LIBS opencv_core opencv_imgproc opencv_highgui)


### PR DESCRIPTION
This should fix errors when other versions of OpenCV are installed in other places. It also removes opencv from being installed via apt-get. 

@edgarriba please test to see if this fixes your problem in #188 
