### PR TITLE
Increase default min number of features to extract

### DIFF
--- a/run.py
+++ b/run.py
@@ -100,7 +100,7 @@ parser.add_argument('--force-ccd',
 
 parser.add_argument('--min-num-features',
                     metavar='<integer>',
-                    default=4000,
+                    default=6000,
                     type=int,
                     help=('Minimum number of features to extract per image. '
                           'More features leads to better results but slower '


### PR DESCRIPTION
At 4000, there were some issues that compounded into stitching problems while texturing. I tested at 8000 and 6000, and found better results.
