### PR TITLE
Altered to work with Pictures without these tags. 

### DIFF
--- a/scripts/resize.py
+++ b/scripts/resize.py
@@ -65,8 +65,8 @@ class ODMResizeCell(ecto.Cell):
                 # copy metadata
                 old_meta.copy(new_meta)
                 # update metadata size
-                new_meta['Exif.Photo.PixelXDimension'].value = img_r.shape[0]
-                new_meta['Exif.Photo.PixelYDimension'].value = img_r.shape[1]
+                new_meta['Exif.Photo.PixelXDimension'] = img_r.shape[0]
+                new_meta['Exif.Photo.PixelYDimension'] = img_r.shape[1]
                 new_meta.write()
                 # update photos array with new values
                 photo.path_file = new_path_file


### PR DESCRIPTION
From the tutorial of pyexif2:
'''
As a handy shortcut, you can always assign a value for a given key regardless of whether it’s already present in the metadata. If a tag was present, its value is overwritten. If the tag was not present, one is created and its value is set:

> > > metadata[key] = value

'''
http://tilloy.net/dev/pyexiv2/tutorial.html
