### PR TITLE
Update about.html

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -77,7 +77,7 @@
 	<hr>
 	<p>Long term, the aim is for the toolchain to also be able to optionally
 	 push to a variety of online data repositories, pushing hi-resolution 
-	aerials to <a href="http://opentopography.org/">OpenAerialMap</a>, point clouds to <a href="http://opentopography.org/">OpenTopography</a>,
+	aerials to <a href="https://openaerialmap.org/">OpenAerialMap</a>, point clouds to <a href="http://opentopography.org/">OpenTopography</a>,
 	 and pushing digital elevation models to an emerging global repository 
 	(yet to be named...). That leaves only digital surface model meshes and 
 	UV textured meshes with no global repository home.</p>


### PR DESCRIPTION
Fixed the link for OpenAerialMap so that it goes to https://openaerialmap.org/ and not to http://opentopography.org/