### PR TITLE
Fixed link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Now that texturing is in the code base, you can access the full textured meshes 
 
 ---
 
-Long term, the aim is for the toolchain to also be able to optionally push to a variety of online data repositories, pushing hi-resolution aerials to [OpenAerialMap](http://opentopography.org/), point clouds to [OpenTopography](http://opentopography.org/), and pushing digital elevation models to an emerging global repository (yet to be named...). That leaves only digital surface model meshes and UV textured meshes with no global repository home.
+Long term, the aim is for the toolchain to also be able to optionally push to a variety of online data repositories, pushing hi-resolution aerials to [OpenAerialMap](https://openaerialmap.org/), point clouds to [OpenTopography](http://opentopography.org/), and pushing digital elevation models to an emerging global repository (yet to be named...). That leaves only digital surface model meshes and UV textured meshes with no global repository home.
 ---
 
 


### PR DESCRIPTION
Fixed the link for OpenAerialMap so that it goes to https://openaerialmap.org/ and not to http://opentopography.org/
