### PR TITLE
mvstexuring typo

### DIFF
--- a/SuperBuild/cmake/External-MvsTexturing.cmake
+++ b/SuperBuild/cmake/External-MvsTexturing.cmake
@@ -1,4 +1,4 @@
-set(_proj_name mvstexuring)
+set(_proj_name mvstexturing)
 set(_SB_BINARY_DIR "${SB_BINARY_DIR}/${_proj_name}")
 
 ExternalProject_Add(${_proj_name}


### PR DESCRIPTION
Here's another `mvstexuring` typo I found, fixed.
