### PR TITLE
Generate tiled, compressed GeoTIFFs

### DIFF
--- a/scripts/odm_orthophoto.py
+++ b/scripts/odm_orthophoto.py
@@ -89,13 +89,13 @@ class ODMOrthoPhotoCell(ecto.Cell):
                 }
 
                 system.run('gdal_translate -a_ullr {ulx} {uly} {lrx} {lry} '
-							'-co TILED=yes'
-							'-co COMPRESS=DEFLATE'
-							'-co PREDICTOR=2'
-							'-co BLOCKXSIZE=256'
-							'-co BLOCKYSIZE=256'
-							'-co INTERLEAVE=band'
-							'-co NUM_THREADS=ALL_CPUS'
+							'-co TILED=yes' 
+							'-co COMPRESS=DEFLATE' 
+							'-co PREDICTOR=2' 
+							'-co BLOCKXSIZE=256' 
+							'-co BLOCKYSIZE=256' 
+							'-co INTERLEAVE=band' 
+							'-co NUM_THREADS=ALL_CPUS' 
                            '-a_srs \"EPSG:{epsg}\" {png} {tiff} > {log}'.format(**kwargs))
                 geotiffcreated = True
             if not geotiffcreated:

--- a/scripts/odm_orthophoto.py
+++ b/scripts/odm_orthophoto.py
@@ -89,6 +89,9 @@ class ODMOrthoPhotoCell(ecto.Cell):
                 }
 
                 system.run('gdal_translate -a_ullr {ulx} {uly} {lrx} {lry} '
+                           '-co TILED=yes -co SPARSE_OK=yes '
+                           '-co BLOCKXSIZE=256 -co BLOCKYSIZE=256 '
+                           '-co INTERLEAVE=BAND -co COMPRESS=JPEG '
                            '-a_srs \"EPSG:{epsg}\" {png} {tiff} > {log}'.format(**kwargs))
                 geotiffcreated = True
             if not geotiffcreated:

--- a/scripts/odm_orthophoto.py
+++ b/scripts/odm_orthophoto.py
@@ -92,6 +92,7 @@ class ODMOrthoPhotoCell(ecto.Cell):
                            '-co TILED=yes -co SPARSE_OK=yes '
                            '-co BLOCKXSIZE=256 -co BLOCKYSIZE=256 '
                            '-co INTERLEAVE=BAND -co COMPRESS=JPEG '
+                           '-co JPEG_QUALITY=90 '
                            '-a_srs \"EPSG:{epsg}\" {png} {tiff} > {log}'.format(**kwargs))
                 geotiffcreated = True
             if not geotiffcreated:

--- a/scripts/odm_orthophoto.py
+++ b/scripts/odm_orthophoto.py
@@ -89,13 +89,13 @@ class ODMOrthoPhotoCell(ecto.Cell):
                 }
 
                 system.run('gdal_translate -a_ullr {ulx} {uly} {lrx} {lry} '
-							'-co TILED=yes' 
-							'-co COMPRESS=DEFLATE' 
-							'-co PREDICTOR=2' 
-							'-co BLOCKXSIZE=256' 
-							'-co BLOCKYSIZE=256' 
-							'-co INTERLEAVE=band' 
-							'-co NUM_THREADS=ALL_CPUS' 
+							'-co TILED=yes '
+							'-co COMPRESS=DEFLATE '
+							'-co PREDICTOR=2 '
+							'-co BLOCKXSIZE=256 '
+							'-co BLOCKYSIZE=256 '
+							'-co INTERLEAVE=band '
+							'-co NUM_THREADS=ALL_CPUS '
                            '-a_srs \"EPSG:{epsg}\" {png} {tiff} > {log}'.format(**kwargs))
                 geotiffcreated = True
             if not geotiffcreated:

--- a/scripts/odm_orthophoto.py
+++ b/scripts/odm_orthophoto.py
@@ -89,10 +89,13 @@ class ODMOrthoPhotoCell(ecto.Cell):
                 }
 
                 system.run('gdal_translate -a_ullr {ulx} {uly} {lrx} {lry} '
-                           '-co TILED=yes -co SPARSE_OK=yes '
-                           '-co BLOCKXSIZE=256 -co BLOCKYSIZE=256 '
-                           '-co INTERLEAVE=BAND -co COMPRESS=JPEG '
-                           '-co JPEG_QUALITY=90 '
+							'-co TILED=yes'
+							'-co COMPRESS=DEFLATE'
+							'-co PREDICTOR=2'
+							'-co BLOCKXSIZE=256'
+							'-co BLOCKYSIZE=256'
+							'-co INTERLEAVE=band'
+							'-co NUM_THREADS=ALL_CPUS'
                            '-a_srs \"EPSG:{epsg}\" {png} {tiff} > {log}'.format(**kwargs))
                 geotiffcreated = True
             if not geotiffcreated:


### PR DESCRIPTION
This allows more efficient access when reading (particularly over a network), as block-level reads become possible. The tile sizing is relatively arbitrary (though larger than the default value of `128`).

Sparse files, band interleaving, and JPEG compression reduce the file size of the resulting images.
