### PR TITLE
Invalid tags in photos will be deleted

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+## Set up library paths
+RUNPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export PYTHONPATH=$RUNPATH/SuperBuild/install/lib/python2.7/dist-packages:$RUNPATH/SuperBuild/src/opensfm:$PYTHONPATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RUNPATH/SuperBuild/install/lib
+
 ## Before installing
 echo "Updating the system"
 sudo apt-get update
@@ -12,7 +17,8 @@ sudo apt-get install -y -qq build-essential \
                      libgdal-dev \
                      gdal-bin \
                      libgeotiff-dev \
-                     pkg-config
+                     pkg-config \
+                     libimage-exiftool-perl
 
 echo "Getting CMake 3.1 for MVS-Texturing"
 sudo apt-get install -y software-properties-common python-software-properties
@@ -53,7 +59,8 @@ sudo apt-get install -y -qq python-networkx \
                      libboost-regex-dev \
                      libboost-python-dev \
                      libboost-date-time-dev \
-                     libboost-thread-dev
+                     libboost-thread-dev \
+                     python-pyproj
 
 sudo pip install -U PyYAML \
                     exifread \

--- a/opendm/types.py
+++ b/opendm/types.py
@@ -69,8 +69,14 @@ class ODM_Photo:
                     self.focal_length = float(val)
             except (pyexiv2.ExifValueError, ValueError) as e:
                 pass
-            except NotImplementedError as e:
-                pass
+            except NotImplementedError:
+                log.ODM_DEBUG('invalid key: %s' %key)
+                log.ODM_DEBUG(
+                    'deleting invalid tags (original image will be saved as ' +
+                    _path_file + '_original)'
+                )
+                tag = key.split('.')[0]
+                system.run('exiftool -%s:all= %s' %(tag, _path_file))
 
         if self.camera_make and self.camera_model:
             self.make_model = sensor_string(self.camera_make, self.camera_model)


### PR DESCRIPTION
Delete with exiftool tags that cant be identified and raise NotImplementedError.
Otherwise, in our case creating orthomosaic was impossible.

Treat this PR as an proposition, because i'm not sure if this match with expected behaviour.
However, in our case where we could not create imagery, it worked well.
