### PR TITLE
Remove band interleaving, increase block size

### DIFF
--- a/scripts/odm_orthophoto.py
+++ b/scripts/odm_orthophoto.py
@@ -92,9 +92,8 @@ class ODMOrthoPhotoCell(ecto.Cell):
 							'-co TILED=yes '
 							'-co COMPRESS=DEFLATE '
 							'-co PREDICTOR=2 '
-							'-co BLOCKXSIZE=256 '
-							'-co BLOCKYSIZE=256 '
-							'-co INTERLEAVE=band '
+							'-co BLOCKXSIZE=512 '
+							'-co BLOCKYSIZE=512 '
 							'-co NUM_THREADS=ALL_CPUS '
                            '-a_srs \"EPSG:{epsg}\" {png} {tiff} > {log}'.format(**kwargs))
                 geotiffcreated = True


### PR DESCRIPTION
Band interleaving confuses some tools that are used to thumbnail TIFFs (e.g. `libvips`).

The increased block size is to match the potentially impending OpenAerialMap file format standard, following the Landsat-on-AWS precedent.
