### PR TITLE
Added dockerfile for march=core2 compilation

### DIFF
--- a/core2.Dockerfile
+++ b/core2.Dockerfile
@@ -1,0 +1,36 @@
+#Pull in previously built packages image with lots of libraries.
+FROM packages
+
+# Prepare directories
+RUN mkdir /code
+WORKDIR /code
+
+# Copy repository files
+COPY ccd_defs_check.py /code/ccd_defs_check.py
+COPY CMakeLists.txt /code/CMakeLists.txt
+COPY configure.sh /code/configure.sh
+COPY /.git/ /code/.git/
+COPY .gitignore /code/.gitignore
+COPY .gitmodules /code/.gitmodules
+COPY /modules/ /code/modules/
+COPY /opendm/ /code/opendm/
+COPY /patched_files/ /code/patched_files/
+COPY run.py /code/run.py
+COPY /scripts/ /code/scripts/
+COPY /SuperBuild/cmake/ /code/SuperBuild/cmake/
+COPY /SuperBuild/CMakeLists.txt /code/SuperBuild/CMakeLists.txt
+COPY /tests/ /code/tests/
+
+# Update submodules
+RUN git submodule init && git submodule update
+
+# Replace g++ and gcc with our own scripts
+COPY /docker/ /code/docker/
+RUN mv -v /usr/bin/gcc /usr/bin/gcc_real && mv -v /usr/bin/g++ /usr/bin/g++_real && cp -v /code/docker/gcc /usr/bin/gcc && cp -v /code/docker/g++ /usr/bin/g++
+
+#Compile code in SuperBuild and root directories
+RUN cd SuperBuild && mkdir build && cd build && cmake .. && make -j$(nproc) \
+    && cd ../.. && mkdir build && cd build && cmake .. && make -j$(nproc)
+
+# Entry point
+ENTRYPOINT ["python", "/code/run.py", "--project-path", "/code/"]

--- a/docker/README
+++ b/docker/README
@@ -1,0 +1,3 @@
+The g++ and gcc scripts in this directory are used to replace the real g++ and gcc programs so that compilation across all projects (including dependencies) uses the -march=core2 flag, which allows us to build a docker image compatible with most CPU architectures.
+
+Without the -march=core2 flag, a docker image will contain binaries that are optimized for the machine that built the image, and will not run on older machines.

--- a/docker/README
+++ b/docker/README
@@ -1,3 +1,3 @@
-The g++ and gcc scripts in this directory are used to replace the real g++ and gcc programs so that compilation across all projects (including dependencies) uses the -march=core2 flag, which allows us to build a docker image compatible with most CPU architectures.
+The g++ and gcc scripts in this directory are used to replace the real g++ and gcc programs so that compilation across all projects (including dependencies) uses the -march=core2 flag, which allows us to build a docker image compatible with most Intel based CPUs.
 
 Without the -march=core2 flag, a docker image will contain binaries that are optimized for the machine that built the image, and will not run on older machines.

--- a/docker/g++
+++ b/docker/g++
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+args=""
+
+for i in "$@"
+do
+    if [[ $i != -march* ]]; then
+        args="$args $i"
+    fi
+done
+
+/usr/bin/g++_real -march=core2 $args

--- a/docker/gcc
+++ b/docker/gcc
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+args=""
+
+for i in "$@"
+do
+    if [[ $i != -march* ]]; then
+        args="$args $i"
+    fi
+done
+
+/usr/bin/gcc_real -march=core2 $args


### PR DESCRIPTION
This PR aims to introduce an alternate Dockerfile for building OpenDroneMap and its dependencies using the "-march=core2" flag in all gcc/g++ invocations. This alternative Dockerfile can be used to create portable docker images (images that can be run on a wide range of intel based CPUs). The standard build process optimizes binaries to run on the CPU for which the image is built against, which results in non-portable images. This problem is evident if the docker image is downloaded on a computer older than the one used to build the image (see https://github.com/pierotofy/node-OpenDroneMap/issues/1).

As the number of dependencies is quite large, it would be unfeasible to manually patch each Makefile; instead I replace the gcc/g++ programs with a script that adds/replace the -march directive to use core2 (see https://gcc.gnu.org/onlinedocs/gcc-4.5.3/gcc/i386-and-x86_002d64-Options.html for other options).

People can still build the image and exploit all available CPU instruction sets using the current Dockerfile.