### PR TITLE
Update config.py

### DIFF
--- a/opendm/config.py
+++ b/opendm/config.py
@@ -232,7 +232,7 @@ def config():
 
     parser.add_argument('--texturing-outlier-removal-type',
                         metavar='<string>',
-                        default='none',
+                        default='gauss_clamping',
                         help=('Type of photometric outlier removal method: ' 
                               '[none, gauss_damping, gauss_clamping]. Default: '  
                               '%(default)s'))


### PR DESCRIPTION
By default ODM should use the`--outlier_removal` feature of mvs texturing. This improves significantly the output when moving features such as cars or people are caught during a survey.

It's also not an option that many people have noticed, since I had none report that it was unusable on node-opendronemap (due to a bug), so I would propose that we turn it on by default.

`gauss_damping` works well also, but I found more aggressive results using `gauss_clamping`.

Without --outlier_removal:

![image](https://cloud.githubusercontent.com/assets/1951843/22840612/3c4404c0-ef9c-11e6-91d8-2b248ec0888e.png)

With --outlier_removal gauss_clamping:

![image](https://cloud.githubusercontent.com/assets/1951843/23105261/704e77d6-f6aa-11e6-9f6b-28c7e1399844.png)

With --outlier_removal gauss_damping:

![image](https://cloud.githubusercontent.com/assets/1951843/23105327/87d50914-f6ab-11e6-8ab8-c3b2fb522385.png)


