### PR TITLE
Update packages.dockerfile

### DIFF
--- a/packages.Dockerfile
+++ b/packages.Dockerfile
@@ -4,6 +4,10 @@ MAINTAINER Alex Hagiopol <alex.hagiopol@icloud.com>
 # Env variables
 ENV DEBIAN_FRONTEND noninteractive
 
+## Ubuntu apt-get update
+RUN apt-get update
+RUN apt-get install -y  software-properties-common
+
 # Add ubuntugis/ppa
 RUN add-apt-repository -y ppa:ubuntugis/ppa
 RUN apt-get update


### PR DESCRIPTION
The docker image build command crashes with the error `add-apt-repository: command not found `. Need to install the module `software-properties-common` before adding ppa. [source](http://askubuntu.com/q/593433/538532)