### PR TITLE
Redirect to opendronemap.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,58 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8">
-		<title>OpenDroneMap</title>
-		<link href="css/style.css" rel="stylesheet">
-		<link href="css/cssmenu.css" rel="stylesheet">
-		<link href="css/cssmenu2.css" rel="stylesheet">
-		<link href='http://fonts.googleapis.com/css?family=BenchNine|Oswald' rel='stylesheet' type='text/css'>
-		<script src="http://code.jquery.com/jquery-latest.min.js" type="text/javascript"></script>
-		<script src="js/script.js"></script>
-	</head>
-	<style>
-	</style>
-	<body>
-	<div id='cssmenu'>
-		<div id="logo"><a href="#"><img src="img/logo.svg"></a></div>
-		<ul>
-		   <li><a href='pages/about.html'><span>About</span></a></li>
-		   <li><a href='https://github.com/OpenDroneMap/OpenDroneMap' target="_blank"><span>Code on GitHub</span></a></li>
-		   <li class='active has-sub'><a href='#'><span>Example Data</span></a>
-			  <ul>
-				 <li><a href='https://github.com/OpenDroneMap/odm_data_benchmark' target="_blank"><span>Benchmark</span></a></li>
-				 <li><a href='https://github.com/OpenDroneMap/odm_data_pacifica' target="_blank"><span>Pacifica (Beach)</span></a></li>
-				 <li><a href='https://github.com/OpenDroneMap/odm_data_langley' target="_blank"><span>Langley (Town Center)</span></a></li>
-				 <li><a href='https://github.com/OpenDroneMap/odm_data_apt' target="_blank"><span>Corridor (Trail)</span></a></li>
-				<li><a href='https://github.com/OpenDroneMap/odm_data_seneca' target="_blank"><span>Seneca (Color Infrared Farm)</span></a></li>
-			  </ul>
-		   </li>
-		   <li><a href='pages/contact.html'><span>Contact</span></a></li>
-		</ul>
-	</div>
-	
-	
-	<div id="container">		
-		<h1 class="main-header"><a href="#"><img src="img/logo_full.svg"></a></h1>
-
-		<h1><i>Open Source Toolkit for processing Civilian Drone Imagery</i></h1>
-		
-		
-		<div id='cssmenu2'>
-			<ul>
-			   <li class='active has-sub'><a href='#'><span>Code & Data</span></a>
-				  <ul>
-					 <li><a href='https://github.com/OpenDroneMap/OpenDroneMap' target="_blank"><span>Code</span></a></li>
-					 <li><a href='https://github.com/OpenDroneMap/odm_data_benchmark' target="_blank"><span>Benchmark</span></a></li>
-					 <li><a href='https://github.com/OpenDroneMap/odm_data_pacifica' target="_blank"><span>Pacifica (Beach)</span></a></li>
-					 <li><a href='https://github.com/OpenDroneMap/odm_data_langley' target="_blank"><span>Langley (Town Center)</span></a></li>
-					 <li><a href='https://github.com/OpenDroneMap/odm_data_apt' target="_blank"><span>Corridor (Trail)</span></a></li>
-					<li><a href='https://github.com/OpenDroneMap/odm_data_seneca' target="_blank"><span>Seneca (Color Infrared Farm)</span></a></li>				  </ul>
-			   </li>
-			</ul>
-		</div>
-		
-	</div>
-	
-	</body>
+  <head>      
+    <title>OpenDroneMap</title>      
+    <meta http-equiv="refresh" content="0;URL='http://opendronemap.org/'" />
+  </head>    
+  <body> 
+    <p>This page has moved to <a href="http://opendronemap.org/">
+      http://opendronemap.org</a>.</p> 
+  </body>    
 </html>


### PR DESCRIPTION
This page is currently out of date, and I think it might be causing confusion for some users.

People should be redirected to opendronemap.org, where more up to date information is available.

p.s. there's also a certificate error when you connect to https://opendronemap.org. The site is accessible without SSL though. http://opendronemap.org