### PR TITLE
OpenAerialMap refers to wrong url #520 upstream.

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@ To pass in custom parameters to the <code>run.py</code> script, simply pass it a
 
 <hr>
 
-<p>Long term, the aim is for the toolchain to also be able to optionally push to a variety of online data repositories, pushing hi-resolution aerials to <a href="http://opentopography.org/">OpenAerialMap</a>, point clouds to <a href="http://opentopography.org/">OpenTopography</a>, and pushing digital elevation models to an emerging global repository (yet to be named...). That leaves only digital surface model meshes and UV textured meshes with no global repository home.</p>
+<p>Long term, the aim is for the toolchain to also be able to optionally push to a variety of online data repositories, pushing hi-resolution aerials to <a href="http://openaerialmap.org/">OpenAerialMap</a>, point clouds to <a href="http://opentopography.org/">OpenTopography</a>, and pushing digital elevation models to an emerging global repository (yet to be named...). That leaves only digital surface model meshes and UV textured meshes with no global repository home.</p>
 
 <hr>
 


### PR DESCRIPTION
anchor was opentopography.org but should be openaerial.org. 