### PR TITLE
Use custom MVS repo

### DIFF
--- a/SuperBuild/cmake/External-MvsTexturing.cmake
+++ b/SuperBuild/cmake/External-MvsTexturing.cmake
@@ -8,8 +8,8 @@ ExternalProject_Add(${_proj_name}
   STAMP_DIR         ${_SB_BINARY_DIR}/stamp
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
-  URL               https://github.com/nmoehrle/mvs-texturing/archive/e695a29505c74be570b8bbb87cf42f5b1611cf60.zip
-  URL_MD5           D11FA3052CEBBF6D34D2072BED6C29FD
+  URL               https://github.com/OpenDroneMap/mvs-texturing/archive/5e16eebae79fc8013064ebc87d0b70ef12e8d416.zip
+  URL_MD5           41A77C2F46A9681864B21E8627406C8C
   #--Update/Patch step----------
   UPDATE_COMMAND    ""
   #--Configure step-------------

--- a/SuperBuild/cmake/External-MvsTexturing.cmake
+++ b/SuperBuild/cmake/External-MvsTexturing.cmake
@@ -8,8 +8,8 @@ ExternalProject_Add(${_proj_name}
   STAMP_DIR         ${_SB_BINARY_DIR}/stamp
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
-  URL               https://github.com/OpenDroneMap/mvs-texturing/archive/5e16eebae79fc8013064ebc87d0b70ef12e8d416.zip
-  URL_MD5           41A77C2F46A9681864B21E8627406C8C
+  URL               https://github.com/nmoehrle/mvs-texturing/archive/44d594d8e1d7a6b323371b1f5f0fbd3e19d7c52a.zip
+  URL_MD5           A21CCA0177522F9747D5F88846B42C11
   #--Update/Patch step----------
   UPDATE_COMMAND    ""
   #--Configure step-------------


### PR DESCRIPTION
There was an update to https://github.com/nmoehrle/mve that caused some issues with installing mvs-texturing. We forked nmoehrle/mvs-texturing to OpenDroneMap/mvs-texturing and pulled a previous version of mve to that installation process. This should be a temporary fix as we would like to keep getting updates to the mvs-texturing software. 

Instructions: 
Run `bash configure.sh reinstall` to make sure the old downloaded files are deleted. 