### PR TITLE
Temporarily changed opensfm-processes to 1

### DIFF
--- a/opendm/config.py
+++ b/opendm/config.py
@@ -148,7 +148,7 @@ def config():
 
     parser.add_argument('--opensfm-processes',
                         metavar='<positive integer>',
-                        default=context.num_cores,
+                        default=1,
                         type=int,
                         help=('The maximum number of processes to use in dense '
                               'reconstruction. Default: %(default)s'))


### PR DESCRIPTION
Many people are having issues with opensfm hanging during either depthmap computation or cleaning. This is likely a Pool problem in opensfm, but further investigation is needed.

In the meanwhile, this at least lets people finish the computation by default.