### PR TITLE
Added warning when an orthophoto cannot be generated due to excessive…

### DIFF
--- a/modules/odm_orthophoto/src/OdmOrthoPhoto.cpp
+++ b/modules/odm_orthophoto/src/OdmOrthoPhoto.cpp
@@ -381,8 +381,13 @@ void OdmOrthoPhoto::createOrthoPhoto()
     }
 
     // Init ortho photo
-    photo_ = cv::Mat::zeros(rowRes, colRes, CV_8UC4) + cv::Scalar(255, 255, 255, 0);
-    depth_ = cv::Mat::zeros(rowRes, colRes, CV_32F) - std::numeric_limits<float>::infinity();
+    try{
+        photo_ = cv::Mat::zeros(rowRes, colRes, CV_8UC4) + cv::Scalar(255, 255, 255, 0);
+        depth_ = cv::Mat::zeros(rowRes, colRes, CV_32F) - std::numeric_limits<float>::infinity();
+    }catch(const cv::Exception &e){
+        std::cerr << "Couldn't allocate enough memory to render the orthophoto (" << colRes << "x" << rowRes << " cells = " << ((long long)colRes * (long long)rowRes * 4) << " bytes). Try to reduce the -resolution parameter or add more RAM.\n";
+        exit(1);
+    }
 
     // Contains the vertices of the mesh.
     pcl::PointCloud<pcl::PointXYZ>::Ptr meshCloud (new pcl::PointCloud<pcl::PointXYZ>);


### PR DESCRIPTION
A user on WebODM reported an error tied to not having enough memory. https://github.com/OpenDroneMap/WebODM/issues/172

I've improved the error message when an orthophoto cannot be generated due to a resolution parameter being too high, or when available RAM is not sufficient.

Thought about linking this too: http://downloadmoreram.com/ but then changed my mind.
