### PR TITLE
Resolves https://github.com/OpenDroneMap/OpenDroneMap/issues/580

### DIFF
--- a/opendm/types.py
+++ b/opendm/types.py
@@ -59,14 +59,13 @@ class ODM_Photo:
             # try/catch tag value due to weird bug in pyexiv2 
             # ValueError: invalid literal for int() with base 10: ''
             try:
-                val = metadata[key].value
                 # parse tag names
                 if key == 'Exif.Image.Make':
-                    self.camera_make = val
+                    self.camera_make = metadata[key].value
                 elif key == 'Exif.Image.Model':
-                    self.camera_model = val
+                    self.camera_model = metadata[key].value
                 elif key == 'Exif.Photo.FocalLength':
-                    self.focal_length = float(val)
+                    self.focal_length = float(metadata[key].value)
             except (pyexiv2.ExifValueError, ValueError) as e:
                 pass
             except NotImplementedError as e:


### PR DESCRIPTION
Issue was caused by data in ImageUniqueID tag, even though data
is populated.

By only reading the values we need from metadata we avoid the issue
in pyexiv2.

Should also improve performance.

stacktrace of error:

.#0  strlen () at ../sysdeps/x86_64/strlen.S:106
.#1  0x00007fffdb154ce7 in exiv2wrapper::ExifTag::ExifTag(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Exiv2::Exifdatum*, Exiv2::ExifData*, Exiv2::ByteOrder) () from /usr/lib/python2.7/dist-packages/libexiv2python.so
.#2  0x00007fffdb154eb4 in exiv2wrapper::Image::getExifTag(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) ()
   from /usr/lib/python2.7/dist-packages/libexiv2python.so
.#3  0x00007fffdb15f3e6 in boost::python::objects::caller_py_function_impl<boost::python::detail::caller<exiv2wrapper::ExifTag const (exiv2wrapper::Image::*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >), boost::python::default_call_policies, boost::mpl::vector3<exiv2wrapper::ExifTag const, exiv2wrapper::Image&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >::operator()(_object*, _object*) ()
   from /usr/lib/python2.7/dist-packages/libexiv2python.so
.#4  0x00007ffff52845cd in boost::python::objects::function::call(_object*, _object*) const () from /usr/lib/x86_64-linux-gnu/libboost_python-py27.so.1.58.0
.#5  0x00007ffff52847c8 in ?? () from /usr/lib/x86_64-linux-gnu/libboost_python-py27.so.1.58.0
.#6  0x00007ffff528c823 in boost::python::detail::exception_handler::operator()(boost::function0<void> const&) const ()
   from /usr/lib/x86_64-linux-gnu/libboost_python-py27.so.1.58.0
.#7  0x00007fffdb15dd63 in boost::detail::function::function_obj_invoker2<boost::_bi::bind_t<bool, boost::python::detail::translate_exception<Exiv2::BasicError<char>, void (*)(Exiv2::BasicError<char> const&)>, boost::_bi::list3<boost::arg<1>, boost::arg<2>, boost::_bi::value<void (*)(Exiv2::BasicError<char> const&)> > >, bool, boost::python::detail::exception_handler const&, boost::function0<void> const&>::invoke(boost::detail::function::function_buffer&, boost::python::detail::exception_handler const&, boost::function0<void> const&) () from /usr/lib/python2.7/dist-packages/libexiv2python.so
.#8  0x00007ffff528c7f8 in boost::python::detail::exception_handler::operator()(boost::function0<void> const&) const ()
   from /usr/lib/x86_64-linux-gnu/libboost_python-py27.so.1.58.0
.#9  0x00007ffff5d01ab8 in boost::python::detail::translate_exception<ecto::except::NullTendril, void (*)(ecto::except::NullTendril const&)>::operator()(boost::python::detail::exception_handler const&, boost::function0<void> const&, void (*)(ecto::except::NullTendril const&)) const ()
   from /home/mribbons/OpenDroneMap170517/SuperBuild/install/lib/python2.7/dist-packages/ecto/ecto_main.so
.#10 0x00007ffff5d0099f in bool boost::_bi::list3<boost::arg<1>, boost::arg<2>, boost::_bi::value<void (*)(ecto::except::NullTendril const&)> >::operator()<bool, boost::python::detail::translate_exception<ecto::except::NullTendril, void (*)(ecto::except::NullTendril const&)>, boost::_bi::list2<boost::python::detail::exception_handler const&, boost::function0<void> const&> >(boost::_bi::type<bool>, boost::python::detail::translate_exception<ecto::except::NullTendril, void (*)(ecto::except::NullTendril const&)>&, boost::_bi::list2<boost::python::detail::exception_handler const&, boost::function0<void> const&>&, long) ()
   from /home/mribbons/OpenDroneMap170517/SuperBuild/install/lib/python2.7/dist-packages/ecto/ecto_main.so
.#11 0x00007ffff5cffbe7 in bool boost::_bi::bind_t<bool, boost::python::detail::translate_exception<ecto::except::NullTendril, void (*)(ecto::except::NullTendril const&)>, boost::_bi::list3<boost::arg<1>, boost::arg<2>, boost::_bi::value<void (*)(ecto::except::NullTendril const&)> > >::operator()<boost::python::detail::exception_handler, boost::function0<void> >(boost::python::detail::exception_handler const&, boost::function0<void> const&) ()
   from /home/mribbons/OpenDroneMap170517/SuperBuild/install/lib/python2.7/dist-packages/ecto/ecto_main.so
.#12 0x00007ffff5cfeb54 in boost::detail::function::function_obj_invoker2<boost::_bi::bind_t<bool, boost::python::detail::translate_exception<ecto::except::NullTendril, void (*)(ecto::except::NullTendril const&)>, boost::_bi::list3<boost::arg<1>, boost::arg<2>, boost::_bi::value<void (*)(ecto::except::NullTendril const&)> > >, bool, boost::python::detail::exception_handler const&, boost::function0<void> const&>::invoke(boost::detail::function::function_buffer&, boost::python::detail::exception_handler const&, boost::function0<void> const&) ()
   from /home/mribbons/OpenDroneMap170517/SuperBuild/install/lib/python2.7/dist-packages/ecto/ecto_main.so
.#13 0x00007ffff528c7f8 in boost::python::detail::exception_handler::operator()(boost::function0<void> const&) const ()
   from /usr/lib/x86_64-linux-gnu/libboost_python-py27.so.1.58.0
...