### PR TITLE
Improved (fixed) GPS Altitude tag detection and parsing

### DIFF
--- a/modules/odm_extract_utm/src/UtmExtractor.cpp
+++ b/modules/odm_extract_utm/src/UtmExtractor.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <cstring>
 #include <iomanip>
 #include <vector>
 #include <cstdlib>
@@ -281,10 +282,11 @@ bool UtmExtractor::parsePosition(std::ifstream &jheadStream, double &lon, double
   std::string latStr, lonStr, altStr;
   while (std::getline(jheadStream, str))
   {
-    size_t index = str.find("GPS Latitude : ");
+    const char* latitudeTag = "GPS Latitude : ";
+    size_t index = str.find(latitudeTag);
     if (index != std::string::npos)
     {
-        latStr = str.substr(index + 15);
+        latStr = str.substr(index + std::strlen(latitudeTag));
         size_t find = latStr.find_first_of("0123456789");
         if(std::string::npos == find)
         {
@@ -292,24 +294,28 @@ bool UtmExtractor::parsePosition(std::ifstream &jheadStream, double &lon, double
         }
 
     }
-    index = str.find("GPS Longitude: ");
+
+    const char* longitudeTag = "GPS Longitude: ";
+    index = str.find(longitudeTag);
     if (index != std::string::npos)
     {
-        lonStr = str.substr(index + 15);
+        lonStr = str.substr(index + std::strlen(longitudeTag));
         size_t find = lonStr.find_first_of("0123456789");
         if(std::string::npos == find)
         {
-            throw UtmExtractorException("Image is missing GPS Latitude data");
+            throw UtmExtractorException("Image is missing GPS Longitude data");
         }
     }
-    index = str.find("GPSAltitude");
+
+    const char* altitudeTag = "GPS Altitude :";
+    index = str.find(altitudeTag);
     if (index != std::string::npos)
     {
-       altStr = str.substr(index + 12);
+       altStr = str.substr(index + std::strlen(altitudeTag));
        size_t find = altStr.find_first_of("0123456789");
        if(std::string::npos == find)
        {
-           throw UtmExtractorException("Image is missing GPS Latitude data");
+           throw UtmExtractorException("Image is missing GPS Altitude data");
        }
     }
   }
@@ -335,21 +341,10 @@ bool UtmExtractor::parsePosition(std::ifstream &jheadStream, double &lon, double
 
   if (!altStr.empty())
   {
-      size_t index = altStr.find_last_of("=");
-      if (index != std::string::npos)
-      {
-          altStr = altStr.substr(index + 1);
-          istr.clear();
-          istr.str(altStr);
-          
-          char dummyChar;
-          int nominator, denominator;
-          istr >> nominator;
-          istr >> dummyChar;
-          istr >> denominator;
-          
-          alt = static_cast<double>(nominator)/static_cast<double>(denominator);
-      }
+    char meterUnitChar;
+    istr.clear();
+    istr.str(altStr);
+    istr >> alt >> meterUnitChar;
   }
 
   return true;


### PR DESCRIPTION
This PR fixes https://github.com/OpenDroneMap/WebODM/issues/185 where OdmExtractUtm produces -nan coordinate for certain datasets containing an XMP section section tag. The following output from jhead:

```
:FocalLength="3/1" exif:FocalLengthIn35mmFilm="15" exif:GPSAltitude="2361/50" exif:GPSAltitudeRef="0
rdf:Seq> <rdf:li>100</rdf:li> </rdf:Seq> </exif:ISOSpeedRatings> <tiff:ImageDescription> <rdf:Alt> <
rdf:li xml:lang="x-default">DCIM\100GOPRO\GOPR1163.</rdf:li> </rdf:Alt> </tiff:ImageDescription> <dc
:description> <rdf:Alt> <rdf:li xml:lang="x-default">DCIM\100GOPRO\GOPR1163.</rdf:li> </rdf:Alt> </d
```

Would cause the parser to override the first "GPSAltitude" tag value by incorrectly parsing:

```
GPSAltitude="2361/50" exif:GPSAltitudeRef="0
```

Which would cause an erroneous value to be wrote in `coords.txt`. I replaced the "GPSAltitude" tag with "GPS Altitude : ", which is more consistent, doesn't suffer from the problem above and is easier to parse.