### PR TITLE
Repair bad index checking

### DIFF
--- a/contrib/visveg/vegind.py
+++ b/contrib/visveg/vegind.py
@@ -17,7 +17,8 @@ try:
     typ = sys.argv[2]
     (fileRoot, fileExt) = os.path.splitext(file)
     outFileName = fileRoot + "_" + typ + fileExt
-    isinstance(typ, ['vari', 'tgi', 'ngrdi'])
+    if typ not in ['vari', 'tgi', 'ngrdi']:
+        raise IndexError
 except (TypeError, IndexError, NameError):
     print bcolors.FAIL + 'Arguments messed up. Check arguments order and index name' + bcolors.ENDC
     print 'Usage: ./vegind.py orto index'


### PR DESCRIPTION
isinstance(object, classinfo) checks only if object has correct python type, not value. Let's try this with more traditional method ;)