### PR TITLE
Added run.sh to dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ COPY /modules/ /code/modules/
 COPY /opendm/ /code/opendm/
 COPY /patched_files/ /code/patched_files/
 COPY run.py /code/run.py
+COPY run.sh /code/run.sh
 COPY /scripts/ /code/scripts/
 COPY /SuperBuild/cmake/ /code/SuperBuild/cmake/
 COPY /SuperBuild/CMakeLists.txt /code/SuperBuild/CMakeLists.txt

--- a/core2.Dockerfile
+++ b/core2.Dockerfile
@@ -38,6 +38,7 @@ COPY /modules/ /code/modules/
 COPY /opendm/ /code/opendm/
 COPY /patched_files/ /code/patched_files/
 COPY run.py /code/run.py
+COPY run.sh /code/run.sh
 COPY /scripts/ /code/scripts/
 COPY /SuperBuild/cmake/ /code/SuperBuild/cmake/
 COPY /SuperBuild/CMakeLists.txt /code/SuperBuild/CMakeLists.txt


### PR DESCRIPTION
This adds the `run.sh` script to the docker images. This is necessary to solve https://github.com/OpenDroneMap/node-OpenDroneMap/issues/25, due to recent changes in node-odm added in https://github.com/OpenDroneMap/node-OpenDroneMap/commit/01e2fdf4721f8b18c66615505c4ddcc756188e50
