### PR TITLE
Fixed utm_pole extraction

### DIFF
--- a/opendm/types.py
+++ b/opendm/types.py
@@ -314,7 +314,7 @@ class ODM_GeoRef(object):
             # match_wgs_utm = re.search('WGS84 UTM (\d{1,2})(N|S)', line, re.I)
             if ref[0] == 'WGS84' and ref[1] == 'UTM':  # match_wgs_utm:
                 self.datum = ref[0]
-                self.utm_pole = ref[2][len(ref) - 1]
+                self.utm_pole = ref[2][len(ref[2]) - 1]
                 self.utm_zone = int(ref[2][:len(ref[2]) - 1])
                 # extract east and west offsets from second line.
                 # We will assume the following format:


### PR DESCRIPTION
Fixes #707.

The reason this came under our radar just recently is that it affects a relatively small area of the world (all single digits UTM zones).

![image](https://user-images.githubusercontent.com/1951843/32640694-ef93610c-c597-11e7-946e-59bd5fcec529.png)

Just by coincidence `len(ref)` is usually `3` (just like `len('12S')`), but fails when the string is only two chars. 😄 
