### PR TITLE
Handle bundler files that have invalid/empty camera parameters

### DIFF
--- a/modules/odm_georef/src/Georef.cpp
+++ b/modules/odm_georef/src/Georef.cpp
@@ -190,6 +190,11 @@ Vec3 GeorefCamera::getReferencedPos()
     return Vec3(easting_,northing_,altitude_);
 }
 
+bool GeorefCamera::isValid()
+{
+    return focalLength_ != 0 && k1_ != 0 && k2_ != 0;
+}
+
 std::ostream& operator<<(std::ostream &os, const GeorefCamera &cam)
 {
     os << "Focal, k1, k2 : " << cam.focalLength_ << ", " << cam.k1_ << ", " << cam.k2_ << "\n";
@@ -1058,7 +1063,14 @@ void Georef::createGeoreferencedModelFromExifData()
     {
         throw GeorefException("Not enough cameras in \'" + inputCoordFilename_ + "\' coord file.\n");
     }
-    
+
+    // Remove invalid cameras
+    std::vector<GeorefCamera> goodCameras;
+    for (size_t i = 0; i < cameras_.size(); i++){
+        if (cameras_[i].isValid()) goodCameras.push_back(cameras_[i]);
+    }
+    cameras_ = goodCameras;
+
     // The optimal camera triplet.
     size_t cam0, cam1, cam2;
     

--- a/modules/odm_georef/src/Georef.cpp
+++ b/modules/odm_georef/src/Georef.cpp
@@ -1067,8 +1067,9 @@ void Georef::createGeoreferencedModelFromExifData()
     // Remove invalid cameras
     std::vector<GeorefCamera> goodCameras;
     for (size_t i = 0; i < cameras_.size(); i++){
-        if (cameras_[i].isValid()) goodCameras.push_back(cameras_[i]);
+        if (cameras_[i].isValid()) goodCameras.push_back(GeorefCamera(cameras_[i]));
     }
+    cameras_.clear();
     cameras_ = goodCameras;
 
     // The optimal camera triplet.

--- a/modules/odm_georef/src/Georef.hpp
+++ b/modules/odm_georef/src/Georef.hpp
@@ -95,6 +95,11 @@ struct GeorefCamera
      * \brief getReferencedPos     Get the georeferenced position of the camera.
      */
     Vec3 getReferencedPos();
+
+    /*!
+     * \brief isValid     Whether this camera is valid based on its parameters.
+     */
+    bool isValid();
     
     double focalLength_;            /**< The focal length of the camera. */
     double k1_;                     /**< The k1 lens distortion parameter. **/


### PR DESCRIPTION
This is a fix for an issue which causes the orthophoto and textured model to be improperly aligned based on EXIF camera positions. The root cause is that OpenSfM, for certain datasets, outputs multiple bundler reconstruction files, and certain cameras that do not appear in certain reconstructions, are initialized to 0 for all parameters.

odm_georef sometimes ends up choosing one of the uninitialized cameras, causing one of the rotation axis to be flipped.

Related discussion on this PR: http://community.opendronemap.org/t/wrong-view-axis/78/13
