### PR TITLE
Added python-gdal package to fix osgeo import error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get install --no-install-recommends -y git cmake python-pip build-essent
 libgtk2.0-dev libavcodec-dev libavformat-dev libswscale-dev python-dev python-numpy libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libjasper-dev libflann-dev \
 libproj-dev libxext-dev liblapack-dev libeigen3-dev libvtk6-dev python-networkx libgoogle-glog-dev libsuitesparse-dev libboost-filesystem-dev libboost-iostreams-dev \
 libboost-regex-dev libboost-python-dev libboost-date-time-dev libboost-thread-dev python-pyproj python-empy python-nose python-pyside python-pyexiv2 python-scipy \
-libexiv2-dev liblas-bin python-matplotlib libatlas-base-dev swig2.0 python-wheel libboost-log-dev libjsoncpp-dev
+libexiv2-dev liblas-bin python-matplotlib libatlas-base-dev swig2.0 python-wheel libboost-log-dev libjsoncpp-dev python-gdal
 
 RUN apt-get remove libdc1394-22-dev
 RUN pip install --upgrade pip

--- a/configure.sh
+++ b/configure.sh
@@ -28,7 +28,8 @@ install() {
                          gdal-bin \
                          libgeotiff-dev \
                          pkg-config \
-                         libjsoncpp-dev
+                         libjsoncpp-dev \
+                         python-gdal
 
     echo "Getting CMake 3.1 for MVS-Texturing"
     sudo apt-get install -y software-properties-common python-software-properties

--- a/core2.Dockerfile
+++ b/core2.Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install --no-install-recommends -y git cmake python-pip build-essent
 libgtk2.0-dev libavcodec-dev libavformat-dev libswscale-dev python-dev python-numpy libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libjasper-dev libflann-dev \
 libproj-dev libxext-dev liblapack-dev libeigen3-dev libvtk6-dev python-networkx libgoogle-glog-dev libsuitesparse-dev libboost-filesystem-dev libboost-iostreams-dev \
 libboost-regex-dev libboost-python-dev libboost-date-time-dev libboost-thread-dev python-pyproj python-empy python-nose python-pyside python-pyexiv2 python-scipy \
-libexiv2-dev liblas-bin python-matplotlib libatlas-base-dev swig2.0 python-wheel libboost-log-dev libjsoncpp-dev
+libexiv2-dev liblas-bin python-matplotlib libatlas-base-dev swig2.0 python-wheel libboost-log-dev libjsoncpp-dev python-gdal
 
 RUN apt-get remove libdc1394-22-dev
 RUN pip install --upgrade pip


### PR DESCRIPTION
Fixes a import error reported by @smathermather 

```
Traceback (most recent call last):
  File "/code/run.py", line 11, in <module>
    from scripts.odm_app import ODMApp
  File "/code/scripts/odm_app.py", line 16, in <module>
    from odm_georeferencing import ODMGeoreferencingCell
  File "/code/scripts/odm_georeferencing.py", line 10, in <module>
    from opendm.cropper import Cropper
  File "/code/opendm/cropper.py", line 4, in <module>
    from osgeo import ogr
ImportError: No module named osgeo
```