### PR TITLE
Fixed single-material rendering bug in odm_orthophoto

### DIFF
--- a/modules/odm_orthophoto/src/OdmOrthoPhoto.cpp
+++ b/modules/odm_orthophoto/src/OdmOrthoPhoto.cpp
@@ -717,20 +717,10 @@ void OdmOrthoPhoto::drawTexturedTriangle(const cv::Mat &texture, const pcl::Vert
     v2x = v2.x; v2y = v2.y; v2z = v2.z;
     v3x = v3.x; v3y = v3.y; v3z = v3.z;
 
-    // Get texture coordinates. (Special cases for PCL when using multiple materials vs one material)
-    if(multiMaterial_)
-    {
-        v1u = uvs[3*faceIndex][0]; v1v = uvs[3*faceIndex][1];
-        v2u = uvs[3*faceIndex+1][0]; v2v = uvs[3*faceIndex+1][1];
-        v3u = uvs[3*faceIndex+2][0]; v3v = uvs[3*faceIndex+2][1];
-
-    }
-    else
-    {
-        v1u = uvs[v1i][0]; v1v = uvs[v1i][1];
-        v2u = uvs[v2i][0]; v2v = uvs[v2i][1];
-        v3u = uvs[v3i][0]; v3v = uvs[v3i][1];
-    }
+    // Get texture coordinates. 
+    v1u = uvs[3*faceIndex][0]; v1v = uvs[3*faceIndex][1];
+    v2u = uvs[3*faceIndex+1][0]; v2v = uvs[3*faceIndex+1][1];
+    v3u = uvs[3*faceIndex+2][0]; v3v = uvs[3*faceIndex+2][1];
 
     // Check bounding box overlap.
     int xMin = static_cast<int>(std::min(std::min(v1x, v2x), v3x));


### PR DESCRIPTION
This is currently affecting many small dataset renderings where mvs-texturing is able to pack all textures in a single material. I expect many people to be affected since mvs-texturing is getting better at packing textures tightly and that this has been lingering in the code base for a while (I've seen similar results a year ago before, but wasn't sure of the cause).

I have the same dataset, one textured with a single material (current mvs-texturing) and an older version of the same dataset textured with multiple materials.

Single material dataset: https://drive.google.com/open?id=1jo7YSQ48XzeuBUnw_LK_YpGbL8JmHEEt

Multiple material dataset: https://drive.google.com/open?id=1z4g6qR5ARNCPSWSBVYNfSkh7IfAM2weu

Problem: multiple material renders fine, but single material renders as following:

![orthophoto](https://user-images.githubusercontent.com/1951843/36924436-88846b3e-1e3c-11e8-9add-5856db886820.png)

Solution:

The UV coordinates calculation for single material datasets in odm_orthophoto seems to be wrong. I can't exactly understand why a conditional logic was required in the lines of code I removed in this proposed fix, but I think they are incorrect. Calculating the UV coordinates following the faceIndex variable for both multi and single materials fixes the issue.

Both datasets render correctly with the fix.

To test:

```
./odm_orthophoto -inputFile /test/singlematerial/odm_texturing/odm_textured_model_geo.obj -outputFile /test/singlematerial/orthophoto.png -resolution 5 -verbose
./odm_orthophoto -inputFile /test/multimaterial/odm_texturing/odm_textured_model_geo.obj -outputFile /test/multimaterial/orthophoto.png -resolution 5 -verbose
```

![orthophoto](https://user-images.githubusercontent.com/1951843/36924583-2e9176ca-1e3d-11e8-916c-a1449ce96e74.png)
