### PR TITLE
Added build type release to PDAL

### DIFF
--- a/SuperBuild/cmake/External-PDAL.cmake
+++ b/SuperBuild/cmake/External-PDAL.cmake
@@ -35,6 +35,7 @@ ExternalProject_Add(${_proj_name}
 	-DWITH_GEOTIFF=ON
 	-DWITH_LASZIP=ON
 	-DWITH_TESTS=OFF
+	-DCMAKE_BUILD_TYPE=Release
     -DCMAKE_INSTALL_PREFIX:PATH=${SB_INSTALL_DIR}
   #--Build step-----------------
   BINARY_DIR        ${_SB_BINARY_DIR}


### PR DESCRIPTION
While looking whether PDAL supports multiple threads, I found that we are building PDAL without optimizations. :upside_down_face: 

I verified this is the case by outputting the build commands from CMake.

Before:

```
cd /code/SuperBuild/build/pdal/vendor/pdalboost && /usr/bin/c++   -DARBITER_CURL -DBOOST_SYSTEM_NO_DEPRECATED -DUNIX -I/code/SuperBuild/src/pdal -I/code/SuperBuild/src/pdal/vendor/pdalboost -I/usr/include/gdal -I/usr/include/geotiff -I/usr/include/jsoncpp -isystem /usr/local/include  -fPIC   -std=c++11 -Wextra -Wall -Wno-unused-parameter -Wno-unused-variable -Wpointer-arith -Wcast-align -Wcast-qual -Wredundant-decls -Wno-long-long -Wno-unknown-pragmas -Wno-deprecated-declarations -o CMakeFiles/pdal_boost.dir/libs/filesystem/src/codecvt_error_category.cpp.o -c /code/SuperBuild/src/pdal/vendor/pdalboost/libs/filesystem/src/codecvt_error_category.cpp
```

Note the absence of the -O3 flag.

After:

```
cd /code/SuperBuild/build/pdal/vendor/pdalboost && /usr/bin/c++   -DARBITER_CURL -DBOOST_SYSTEM_NO_DEPRECATED -DUNIX -I/code/SuperBuild/src/pdal -I/code/SuperBuild/src/pdal/vendor/pdalboost -I/usr/include/gdal -I/usr/include/geotiff -I/usr/include/jsoncpp -isystem /usr/local/include  -fPIC -O3 -DNDEBUG   -std=c++11 -Wextra -Wall -Wno-unused-parameter -Wno-unused-variable -Wpointer-arith -Wcast-align -Wcast-qual -Wredundant-decls -Wno-long-long -Wno-unknown-pragmas -Wno-deprecated-declarations -o CMakeFiles/pdal_boost.dir/libs/filesystem/src/codecvt_error_category.cpp.o -c /code/SuperBuild/src/pdal/vendor/pdalboost/libs/filesystem/src/codecvt_error_category.cpp
```

This should increase performance all over. :clinking_glasses: 