### PR TITLE
Fixes to get non-georeferenced images to process correctly

### DIFF
--- a/opendm/types.py
+++ b/opendm/types.py
@@ -132,18 +132,20 @@ class ODM_Reconstruction(object):
     def __init__(self, photos, projstring = None, coords_file = None):
         self.photos = photos    # list of ODM_Photos
         self.projection = None  # Projection system the whole project will be in
+        self.georef = None
         if projstring:
             self.projection = self.set_projection(projstring)
             self.georef = ODM_GeoRef(self.projection)
         else:
             self.projection = self.parse_coordinate_system(coords_file)
-            self.georef = ODM_GeoRef(self.projection)
+            if self.projection:
+                self.georef = ODM_GeoRef(self.projection)
 
     def parse_coordinate_system(self, _file):
         """Write attributes to jobOptions from coord file"""
         # check for coordinate file existence
         if not io.file_exists(_file):
-            log.ODM_ERROR('Could not find file %s' % _file)
+            log.ODM_WARNING('Could not find file %s' % _file)
             return
 
         with open(_file) as f:

--- a/scripts/dataset.py
+++ b/scripts/dataset.py
@@ -111,9 +111,11 @@ class ODMLoadDatasetCell(ecto.Cell):
         else:
             outputs.reconstruction = types.ODM_Reconstruction(photos, projstring=self.params.proj)
 
-        # Save proj to file for future use
-        with open(io.join_paths(tree.odm_georeferencing, tree.odm_georeferencing_proj), 'w') as f:
-            f.write(outputs.reconstruction.projection.srs)
+        # Save proj to file for future use (unless this 
+        # dataset is not georeferenced)
+        if outputs.reconstruction.projection:
+            with open(io.join_paths(tree.odm_georeferencing, tree.odm_georeferencing_proj), 'w') as f:
+                f.write(outputs.reconstruction.projection.srs)
 
         log.ODM_INFO('Running ODM Load Dataset Cell - Finished')
         return ecto.OK if args.end_with != 'dataset' else ecto.QUIT

--- a/scripts/odm_orthophoto.py
+++ b/scripts/odm_orthophoto.py
@@ -80,7 +80,7 @@ class ODMOrthoPhotoCell(ecto.Cell):
             geotiffcreated = False
             georef = reconstruction.georef
 
-            if georef.projection and georef.utm_east_offset and georef.utm_north_offset:
+            if georef and georef.projection and georef.utm_east_offset and georef.utm_north_offset:
                 ulx = uly = lrx = lry = 0.0
                 with open(tree.odm_orthophoto_corners) as f:
                     for lineNumber, line in enumerate(f):

--- a/scripts/run_opensfm.py
+++ b/scripts/run_opensfm.py
@@ -184,8 +184,9 @@ class ODMOpenSfMCell(ecto.Cell):
             else:
                 log.ODM_WARNING('Found a valid CMVS file in: %s' % tree.pmvs_visdat)
 
-        system.run('PYTHONPATH=%s %s/bin/opensfm export_geocoords %s --transformation --proj \'%s\'' %
-                   (context.pyopencv_path, context.opensfm_path, tree.opensfm, reconstruction.georef.projection.srs))
+        if reconstruction.georef:
+            system.run('PYTHONPATH=%s %s/bin/opensfm export_geocoords %s --transformation --proj \'%s\'' %
+                       (context.pyopencv_path, context.opensfm_path, tree.opensfm, reconstruction.georef.projection.srs))
 
         outputs.reconstruction = reconstruction
 


### PR DESCRIPTION
A recent update broke the ability to process images that have no EXIF GPS information or GCPs datasets. These changes allow users to process non-georeferenced images again.

Fixes #799, http://community.opendronemap.org/t/could-not-find-file-odm-georeferencing-coords-txt/487