### PR TITLE
Fixed gippy dependency

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -100,7 +100,7 @@ install() {
     echo "Installing split-merge Dependencies"
     pip install -U scipy shapely numpy pyproj
 
-    pip install -U https://github.com/OpenDroneMap/gippy/archive/v0.3.9.tar.gz psutil
+    pip install -U gippy psutil
 
     echo "Compiling SuperBuild"
     cd ${RUNPATH}/SuperBuild


### PR DESCRIPTION
The update to gippy 1.0 was done in the docker builds, but not in the configure.sh file (I apologize). This change fixes the problem.