### PR TITLE
Added _proj_name to download paths to avoid conflicts

### DIFF
--- a/SuperBuild/cmake/External-LASzip.cmake
+++ b/SuperBuild/cmake/External-LASzip.cmake
@@ -7,7 +7,7 @@ ExternalProject_Add(${_proj_name}
   TMP_DIR           ${_SB_BINARY_DIR}/tmp
   STAMP_DIR         ${_SB_BINARY_DIR}/stamp
   #--Download step--------------
-  DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
+  DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}/${_proj_name}
   URL               https://github.com/LASzip/LASzip/archive/master.zip
   #--Update/Patch step----------
   UPDATE_COMMAND    ""

--- a/SuperBuild/cmake/External-MvsTexturing.cmake
+++ b/SuperBuild/cmake/External-MvsTexturing.cmake
@@ -7,7 +7,7 @@ ExternalProject_Add(${_proj_name}
   TMP_DIR           ${_SB_BINARY_DIR}/tmp
   STAMP_DIR         ${_SB_BINARY_DIR}/stamp
   #--Download step--------------
-  DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
+  DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}/${_proj_name}
   URL               https://github.com/OpenDroneMap/mvs-texturing/archive/master.zip
   #--Update/Patch step----------
   UPDATE_COMMAND    ""


### PR DESCRIPTION
Otherwise `master.zip` from one dependency overrides other `master.zip` from other dependencies.