### PR TITLE
Set PDAL version to 1.6, LASzip to release from the same time period

### DIFF
--- a/SuperBuild/cmake/External-LASzip.cmake
+++ b/SuperBuild/cmake/External-LASzip.cmake
@@ -8,7 +8,7 @@ ExternalProject_Add(${_proj_name}
   STAMP_DIR         ${_SB_BINARY_DIR}/stamp
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}/${_proj_name}
-  URL               https://github.com/LASzip/LASzip/archive/master.zip
+  URL               https://github.com/LASzip/LASzip/archive/0069c42307183c49744f1eb170f7032a8cf6a9db.zip
   #--Update/Patch step----------
   UPDATE_COMMAND    ""
   #--Configure step-------------

--- a/SuperBuild/cmake/External-PDAL.cmake
+++ b/SuperBuild/cmake/External-PDAL.cmake
@@ -8,7 +8,7 @@ ExternalProject_Add(${_proj_name}
   STAMP_DIR         ${_SB_BINARY_DIR}/stamp
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
-  URL               https://github.com/PDAL/PDAL/releases/download/1.7.2/PDAL-1.7.2-src.tar.gz
+  URL               https://github.com/PDAL/PDAL/archive/1.6.zip
   #--Update/Patch step----------
   UPDATE_COMMAND    ""
   #--Configure step-------------


### PR DESCRIPTION
PDAL 1.7 seems to have a problem with the gdal writer driver while processing DSM/DTM products. Reverting to 1.6 fixes the problem, while allowing to continue using LAZ compression on outputs.