### PR TITLE
Froze gippy version to 1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ libexiv2-dev liblas-bin python-matplotlib libatlas-base-dev swig2.0 python-wheel
 RUN apt-get remove libdc1394-22-dev
 RUN pip install --upgrade pip
 RUN pip install setuptools
-RUN pip install -U PyYAML exifread gpxpy xmltodict catkin-pkg appsettings gippy loky shapely numpy pyproj psutil && pip install -U scipy --ignore-installed
+RUN pip install -U PyYAML exifread gpxpy xmltodict catkin-pkg appsettings https://github.com/gipit/gippy/archive/v1.0.0.zip loky shapely numpy pyproj psutil && pip install -U scipy --ignore-installed
 
 ENV PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python2.7/dist-packages"
 ENV PYTHONPATH="$PYTHONPATH:/code/SuperBuild/src/opensfm"

--- a/configure.sh
+++ b/configure.sh
@@ -100,7 +100,7 @@ install() {
     echo "Installing split-merge Dependencies"
     pip install -U scipy shapely numpy pyproj
 
-    pip install -U gippy psutil
+    pip install -U https://github.com/gipit/gippy/archive/v1.0.0.zip psutil
 
     echo "Compiling SuperBuild"
     cd ${RUNPATH}/SuperBuild

--- a/core2.Dockerfile
+++ b/core2.Dockerfile
@@ -19,7 +19,7 @@ libexiv2-dev liblas-bin python-matplotlib libatlas-base-dev swig2.0 python-wheel
 RUN apt-get remove libdc1394-22-dev
 RUN pip install --upgrade pip
 RUN pip install setuptools
-RUN pip install -U PyYAML exifread gpxpy xmltodict catkin-pkg appsettings gippy loky shapely numpy pyproj psutil && pip install -U scipy --ignore-installed
+RUN pip install -U PyYAML exifread gpxpy xmltodict catkin-pkg appsettings https://github.com/gipit/gippy/archive/v1.0.0.zip loky shapely numpy pyproj psutil && pip install -U scipy --ignore-installed
 
 ENV PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python2.7/dist-packages"
 ENV PYTHONPATH="$PYTHONPATH:/code/SuperBuild/src/opensfm"


### PR DESCRIPTION
This is a fix affecting all DEM products, caused by updates in the `gippy` repository which seems to be broken as of the latest release picked by pip and creates empty GeoTIFFs.

`gippy==1.0.0` also is no longer available (?) from pypi, even though we've been installing it just fine until now.

Installing directly from GitHub brings things back to working.