### PR TITLE
Fixed processes build limit in configure.sh

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 
+if [[ $2 =~ ^[0-9]+$ ]] ; then
+    processes=$2
+else
+    processes=$(nproc)
+fi
+
 install() {
     ## Set up library paths
-
     export PYTHONPATH=$RUNPATH/SuperBuild/install/lib/python2.7/dist-packages:$RUNPATH/SuperBuild/src/opensfm:$PYTHONPATH
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RUNPATH/SuperBuild/install/lib
-
-    if [[ $2 =~ ^[0-9]+$ ]] ; then
-        processes=$2
-    else
-        processes=$(nproc)
-    fi
 
     ## Before installing
     echo "Updating the system"


### PR DESCRIPTION
The configure.sh script references $2 within the `install` function, but $2 references the parameters passed to the function (none), not the command line arguments, so $2 always eval to none and a user cannot limit the number of build processes.

This PR fixes it.