### PR TITLE
Fix VTK build error for certain environments

### DIFF
--- a/modules/odm_georef/CMakeLists.txt
+++ b/modules/odm_georef/CMakeLists.txt
@@ -12,6 +12,7 @@ find_library(PROJ4_LIBRARY "libproj.so" PATHS "/usr/lib" "/usr/lib/x86_64-linux-
 add_definitions(-Wall -Wextra -Wconversion -pedantic -std=c++11)
 
 # Find pcl at the location specified by PCL_DIR
+find_package(VTK 6.0 REQUIRED)
 find_package(PCL 1.8 HINTS "${PCL_DIR}/share/pcl-1.8")
 
 # Find OpenCV at the default location

--- a/modules/odm_meshing/CMakeLists.txt
+++ b/modules/odm_meshing/CMakeLists.txt
@@ -8,6 +8,7 @@ set(PCL_DIR "PCL_DIR-NOTFOUND" CACHE "PCL_DIR" "Path to the pcl installation dir
 add_definitions(-Wall -Wextra)
 
 # Find pcl at the location specified by PCL_DIR
+find_package(VTK 6.0 REQUIRED)
 find_package(PCL 1.8 HINTS "${PCL_DIR}/share/pcl-1.8")
 
 # Add the PCL and Eigen include dirs. 

--- a/modules/odm_orthophoto/CMakeLists.txt
+++ b/modules/odm_orthophoto/CMakeLists.txt
@@ -9,6 +9,7 @@ set(OPENCV_DIR "OPENCV_DIR-NOTFOUND" CACHE "OPENCV_DIR" "Path to the OPENCV inst
 add_definitions(-Wall -Wextra)
 
 # Find pcl at the location specified by PCL_DIR
+find_package(VTK 6.0 REQUIRED)
 find_package(PCL 1.8 HINTS "${PCL_DIR}/share/pcl-1.8" REQUIRED)
 
 # Find OpenCV at the default location

--- a/modules/odm_slam/CMakeLists.txt
+++ b/modules/odm_slam/CMakeLists.txt
@@ -8,6 +8,7 @@ set(OPENCV_DIR "OPENCV_DIR-NOTFOUND" CACHE "OPENCV_DIR" "Path to the opencv inst
 add_definitions(-Wall -Wextra)
 
 # Find pcl at the location specified by PCL_DIR
+find_package(VTK 6.0 REQUIRED)
 find_package(PCL 1.8 HINTS "${PCL_DIR}/share/pcl-1.8" REQUIRED)
 
 # Find OpenCV at the default location


### PR DESCRIPTION
Depending on the speed of your computer and the order in which executables are built, sometimes certain odm modules that depend on PCL will fail to build because they will try to link to VTK 7 (used by the 2.5D meshing module) instead of VTK 6 (the version used by PCL 1.8 installed via libvtk6-dev).

Adding a find_package instruction makes the build more robust.

```
[ 21%] Linking CXX executable ../../bin/odm_georef
/usr/bin/ld: cannot find -lvtkftgl
/usr/bin/ld: cannot find -lvtkFiltersParallelFlowPaths
/usr/bin/ld: cannot find -lvtkParallelMPI
/usr/bin/ld: cannot find -lvtkFiltersParallelGeometry
/usr/bin/ld: cannot find -lvtkFiltersParallelMPI
/usr/bin/ld: cannot find -lvtkFiltersParallelStatistics
/usr/bin/ld: cannot find -lvtkFiltersPython
/usr/bin/ld: cannot find -lvtkWrappingPythonCore
/usr/bin/ld: cannot find -lvtkWrappingTools
/usr/bin/ld: cannot find -lvtkFiltersReebGraph
/usr/bin/ld: cannot find -lvtkGeovisCore
/usr/bin/ld: cannot find -lvtkInteractionStyle
/usr/bin/ld: cannot find -lvtkInteractionWidgets
/usr/bin/ld: cannot find -lvtkRenderingAnnotation
/usr/bin/ld: cannot find -lvtkRenderingVolume
/usr/bin/ld: cannot find -lvtkViewsCore
collect2: error: ld returned 1 exit status
modules/odm_georef/CMakeFiles/odm_georef.dir/build.make:494: recipe for target 'bin/odm_georef' failed
make[2]: *** [bin/odm_georef] Error 1
CMakeFiles/Makefile2:170: recipe for target 'modules/odm_georef/CMakeFiles/odm_georef.dir/all' failed
```

This PR fixes the problem.