### PR TITLE
Change default smvs-output-scale parameter

### DIFF
--- a/opendm/config.py
+++ b/opendm/config.py
@@ -220,7 +220,7 @@ def config():
 
     parser.add_argument('--smvs-output-scale',
                         metavar='<positive integer>',
-                        default=2,
+                        default=1,
                         type=int,
                         help='The scale of the optimization - the '
                         'finest resolution of the bicubic patches will have the'


### PR DESCRIPTION
I'd propose to change the default value of `smvs-output-scale` from `2` to `1`.

According to https://github.com/flanggut/smvs/issues/28 it creates more accurate reconstructions.

Running on a simple dataset seem to lead better results.

![screen](https://user-images.githubusercontent.com/1951843/46218319-476db580-c312-11e8-934b-676967ea95f5.gif)

(Note how the roof of the building is reconstructed with greater detail).