### PR TITLE
Warn about possible malformed GCPs in the log

### DIFF
--- a/modules/odm_georef/src/Georef.hpp
+++ b/modules/odm_georef/src/Georef.hpp
@@ -53,6 +53,8 @@ struct GeorefGCP
     std::string image_;     /**< The corresponding image for the GCP **/
     std::string idgcp_;     /**< The corresponding identification for the GCP **/
 
+    size_t largeErrors = 0;
+
     GeorefGCP();
     ~GeorefGCP();
 


### PR DESCRIPTION
This is a code addition to help diagnose GCP issues in the future.

It attempts to detect GCPs that constantly produce a large (more than 10 meters) georeferencing error.

```
WARNING: Detected possible malformed GCP # 73: 168321 large georeferencing errors.
WARNING: Detected possible malformed GCP # 85: 223415 large georeferencing errors.
```

Hope this can be helpful to others. Not sure it's the best approach, but seems to have served the purpose for the analysis in https://github.com/OpenDroneMap/WebODM/issues/549

