### PR TITLE
Implemented images database

### DIFF
--- a/opendm/types.py
+++ b/opendm/types.py
@@ -17,7 +17,6 @@ class ODM_Photo:
 
     def __init__(self, path_file, force_focal, force_ccd):
         #  general purpose
-        self.path_file = path_file
         self.filename = io.extract_file_from_path_file(path_file)
         # useful attibutes
         self.width = None
@@ -33,7 +32,7 @@ class ODM_Photo:
         self.longitude = None
         self.altitude = None
         # parse values from metadata
-        self.parse_exif_values(self.path_file, force_focal, force_ccd)
+        self.parse_exif_values(path_file, force_focal, force_ccd)
         # compute focal length into pixels
         self.update_focal()
 

--- a/opendm/types.py
+++ b/opendm/types.py
@@ -38,9 +38,13 @@ class ODM_Photo:
         self.update_focal()
 
         # print log message
-        log.ODM_DEBUG('Loaded {} | camera: {} | dimensions: {} x {} | focal: {} | ccd: {} | lat: {} | lon: {} | alt: {}'
-                      .format(self.filename, self.make_model, self.width, self.height, self.focal_length,
-                              self.ccd_width, self.latitude, self.longitude, self.altitude))
+        log.ODM_DEBUG('Loaded {}'.format(self))
+
+
+    def __str__(self):
+        return '{} | camera: {} | dimensions: {} x {} | focal: {} | ccd: {} | lat: {} | lon: {} | alt: {}'.format(
+                            self.filename, self.make_model, self.width, self.height, self.focal_length,
+                            self.ccd_width, self.latitude, self.longitude, self.altitude)
 
     def update_focal(self):
         # compute focal length in pixels

--- a/scripts/dataset.py
+++ b/scripts/dataset.py
@@ -22,6 +22,8 @@ def save_images_database(photos, database_file):
     log.ODM_INFO("Wrote images database: %s" % database_file)
 
 def load_images_database(database_file):
+    # Empty is used to create types.ODM_Photo class
+    # instances without calling __init__
     class Empty:
         pass
 

--- a/scripts/dataset.py
+++ b/scripts/dataset.py
@@ -1,5 +1,6 @@
 import os
 import ecto
+import json
 
 from opendm import context
 from opendm import io
@@ -14,6 +15,30 @@ def make_odm_photo(force_focal, force_ccd, path_file):
                            force_focal,
                            force_ccd)
 
+def save_images_database(photos, database_file):
+    with open(database_file, 'w') as f:
+        f.write(json.dumps(map(lambda p: p.__dict__, photos)))
+    
+    log.ODM_INFO("Wrote images database: %s" % database_file)
+
+def load_images_database(database_file):
+    class Empty:
+        pass
+
+    result = []
+
+    log.ODM_INFO("Loading images database: %s" % database_file)
+
+    with open(database_file, 'r') as f:
+        photos_json = json.load(f)
+        for photo_json in photos_json:
+            p = Empty()
+            for k in photo_json:
+                setattr(p, k, photo_json[k])
+            p.__class__ = types.ODM_Photo
+            result.append(p)
+
+    return result
 
 class ODMLoadDatasetCell(ecto.Cell):
 
@@ -63,22 +88,36 @@ class ODMLoadDatasetCell(ecto.Cell):
 
         log.ODM_DEBUG('Loading dataset from: %s' % images_dir)
 
-        files = get_images(images_dir)
+        # check if we rerun cell or not
+        rerun_cell = (args.rerun is not None and
+                      args.rerun == 'dataset') or \
+                     (args.rerun_all) or \
+                     (args.rerun_from is not None and
+                      'dataset' in args.rerun_from)
+        
+        images_database_file = io.join_paths(tree.root_path, 'images.json')
+        if not io.file_exists(images_database_file) or rerun_cell:
+            files = get_images(images_dir)
+            if files:
+                # create ODMPhoto list
+                path_files = [io.join_paths(images_dir, f) for f in files]
 
-        if files:
-            # create ODMPhoto list
-            path_files = [io.join_paths(images_dir, f) for f in files]
+                photos = []
+                with open(tree.dataset_list, 'w') as dataset_list:
+                    for files in path_files:
+                        photos += [make_odm_photo(self.params.force_focal, self.params.force_ccd, files)]
+                        dataset_list.write(photos[-1].filename + '\n')
 
-            photos = []
-            with open(tree.dataset_list, 'w') as dataset_list:
-                for files in path_files:
-                    photos += [make_odm_photo(self.params.force_focal, self.params.force_ccd, files)]
-                    dataset_list.write(photos[-1].filename + '\n')
-
-            log.ODM_INFO('Found %s usable images' % len(photos))
+                # Save image database for faster restart
+                save_images_database(photos, images_database_file)
+            else:
+                log.ODM_ERROR('Not enough supported images in %s' % images_dir)
+                return ecto.QUIT
         else:
-            log.ODM_ERROR('Not enough supported images in %s' % images_dir)
-            return ecto.QUIT
+            # We have an images database, just load it
+            photos = load_images_database(images_database_file)
+
+        log.ODM_INFO('Found %s usable images' % len(photos))
 
         # append photos to cell output
         if not self.params.proj:
@@ -99,9 +138,12 @@ class ODMLoadDatasetCell(ecto.Cell):
 
                 # run UTM extraction binary
                 try:
-                    system.run('{bin}/odm_extract_utm -imagesPath {imgs}/ '
-                                                        '-imageListFile {imgs_list} -outputCoordFile {coords} {verbose} '
-                                                        '-logFile {log}'.format(**kwargs))
+                    if not io.file_exists(tree.odm_georeferencing_coords) or rerun_cell:
+                        system.run('{bin}/odm_extract_utm -imagesPath {imgs}/ '
+                                                            '-imageListFile {imgs_list} -outputCoordFile {coords} {verbose} '
+                                                            '-logFile {log}'.format(**kwargs))
+                    else:
+                        log.ODM_INFO("Coordinates file already exist: %s" % tree.odm_georeferencing_coords)
                 except:
                     log.ODM_WARNING('Could not generate coordinates file. '
                                     'Ignore if there is a GCP file')

--- a/scripts/run_opensfm.py
+++ b/scripts/run_opensfm.py
@@ -66,7 +66,7 @@ class ODMOpenSfMCell(ecto.Cell):
                 for photo in photos:
                     if not photo.altitude:
                         has_alt = False
-                    fout.write('%s\n' % photo.path_file)
+                    fout.write('%s\n' % io.join_paths(tree.dataset_raw, photo.filename))
 
             # create config file for OpenSfM
             config = [


### PR DESCRIPTION
This PR speeds up reprocessing of an existing dataset by saving on disk an images database (found at `path-to-dataset/images.json` and loading it when available instead of re-reading each individual image.

It also avoid reruns of `odm_extract_utm`, unless rerun parameters are specified.

cc @smathermather 

Completes #917 