### PR TITLE
Make skip-3dmodel and use_3dmesh args collision forgiving

### DIFF
--- a/opendm/config.py
+++ b/opendm/config.py
@@ -556,7 +556,7 @@ def config():
       args.pc_classify = "smrf"
 
     if args.skip_3dmodel and args.use_3dmesh:
-      log.ODM_WARNING('--skip-3dmodel is set, but so is --use-3dmesh. You can\'t have both!')
-      sys.exit(1)
+      log.ODM_WARNING('--skip-3dmodel is set, but so is --use-3dmesh. --skip-3dmodel will be ignored.')
+      args.skip_3dmodel = False
 
     return args

--- a/opendm/config.py
+++ b/opendm/config.py
@@ -556,7 +556,7 @@ def config():
       args.pc_classify = "smrf"
 
     if args.skip_3dmodel and args.use_3dmesh:
-      log.ODM_WARNING('--skip-3dmodel is set, but so is --use-3dmesh. --skip-3dmodel will be ignored.')
-      args.skip_3dmodel = False
+      log.ODM_WARNING('--skip-3dmodel is set, but so is --use-3dmesh. --use_3dmesh will be ignored.')
+      args.use_3dmesh = False
 
     return args


### PR DESCRIPTION
This PR proposes to make the collision of `skip-3dmodel` and `use-3dmesh` forgiving instead of making the application quit with an error, since a lot of users setting `--fast-orthophoto` do not realize that this causes `--use-3dmesh` to be set.