### PR TITLE
Update pdal to 1.8.0

### DIFF
--- a/SuperBuild/cmake/External-PDAL.cmake
+++ b/SuperBuild/cmake/External-PDAL.cmake
@@ -8,7 +8,7 @@ ExternalProject_Add(${_proj_name}
   STAMP_DIR         ${_SB_BINARY_DIR}/stamp
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
-  URL               https://github.com/PDAL/PDAL/archive/1.6.zip
+  URL               https://github.com/PDAL/PDAL/archive/1.8.0.zip
   #--Update/Patch step----------
   UPDATE_COMMAND    ""
   #--Configure step-------------

--- a/opendm/dem/pdal.py
+++ b/opendm/dem/pdal.py
@@ -155,6 +155,7 @@ def run_pipeline(json, verbose=False):
     cmd = [
         'pdal',
         'pipeline',
+        '--nostream',
         '-i %s' % jsonfile
     ]
     if verbose:


### PR DESCRIPTION
Modify project to use current release PDAL 1.8.0.  

By default PDAL 1.8.0 will utilise stream mode if appropriate, which also requires additional 'bounds' parameters.  Adding the '--nostream' parameter forces it to standard mode so that it will act like PDAL 1.6.  

Further work is needed to implement stream mode (which can be looked at separately).  Stream mode 'might' help with very large files but also may slow processing down as getting the bounds from 'pdal info' does take some time.

This has been tested only with a 600 photo set (20Mpx), with no resize.  The '--nostream' was not required for an ortho-only (sparse) .ply, but was required for a full (dense) .ply.

PDAL 1.9 is soon to be released (currently RC) but requires GDAL 2.2+.  The repo version for Ubuntu 16.04 is only 2.1.3 so additional work would be needed to update further.