### PR TITLE
Do not include extras in GCP UTM copy

### DIFF
--- a/opendm/gcp.py
+++ b/opendm/gcp.py
@@ -63,7 +63,7 @@ class GCPFile:
             utm_zone, hemisphere = location.get_utm_zone_and_hemisphere_from(lon, lat)
             return "WGS84 UTM %s%s" % (utm_zone, hemisphere)
 
-    def create_utm_copy(self, gcp_file_output, filenames=None, rejected_entries=None):
+    def create_utm_copy(self, gcp_file_output, filenames=None, rejected_entries=None, include_extras=True):
         """
         Creates a new GCP file from an existing GCP file
         by optionally including only filenames and reprojecting each point to 
@@ -80,6 +80,8 @@ class GCPFile:
         for entry in self.iter_entries():
             if filenames is None or entry.filename in filenames:
                 entry.x, entry.y, entry.z = transformer.TransformPoint(entry.x, entry.y, entry.z)
+                if not include_extras:
+                    entry.extras = ''
                 output.append(str(entry))
             elif isinstance(rejected_entries, list):
                 rejected_entries.append(entry)

--- a/opendm/types.py
+++ b/opendm/types.py
@@ -111,7 +111,7 @@ class ODM_Reconstruction(object):
                 # Convert GCP file to a UTM projection since the rest of the pipeline
                 # does not handle other SRS well.
                 rejected_entries = []
-                utm_gcp = GCPFile(gcp.create_utm_copy(output_gcp_file, filenames=[p.filename for p in self.photos], rejected_entries=rejected_entries))
+                utm_gcp = GCPFile(gcp.create_utm_copy(output_gcp_file, filenames=[p.filename for p in self.photos], rejected_entries=rejected_entries, include_extras=False))
                 
                 if not utm_gcp.exists():
                     raise RuntimeError("Could not project GCP file to UTM. Please double check your GCP file for mistakes.")

--- a/tests/test_gcp.py
+++ b/tests/test_gcp.py
@@ -57,5 +57,13 @@ class TestGcp(unittest.TestCase):
         gcp = GCPFile(None)
         self.assertFalse(gcp.exists())
 
+    def test_gcp_extras(self):
+        gcp = GCPFile('tests/assets/gcp_extras.txt')
+        self.assertEqual(gcp.get_entry(0).extras, 'gcp1')
+
+        copy = GCPFile(gcp.create_utm_copy("tests/assets/output/gcp_utm_no_extras.txt", include_extras=False))
+        self.assertTrue(copy.exists())
+        self.assertEqual(copy.get_entry(0).extras, '')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes a problem with extras fields in the new GCP code.

```
Starting incremental reconstruction Traceback (most recent call last): File "/code/SuperBuild/src/opensfm/bin/opensfm", line 34, in <module> command.run(args) File "/code/SuperBuild/src/opensfm/opensfm/commands/reconstruct.py", line 23, in run incremental_reconstruction(data, graph) File "/code/SuperBuild/src/opensfm/opensfm/reconstruction.py", line 1304, in incremental_reconstruction gcp = data.load_ground_control_points() File "/code/SuperBuild/src/opensfm/opensfm/dataset.py", line 712, in load_ground_control_points gcp = io.read_gcp_list(fin, reference, exif) File "/code/SuperBuild/src/opensfm/opensfm/io.py", line 455, in read_gcp_list points = _read_gcp_list_lines(lines, projection, reference, exif) File "/code/SuperBuild/src/opensfm/opensfm/io.py", line 400, in _read_gcp_list_lines d = exif[shot_id] KeyError : u'13-DJI_0383.jpg gcp05' 
```