### PR TITLE
Removed --images arg

### DIFF
--- a/opendm/config.py
+++ b/opendm/config.py
@@ -571,7 +571,7 @@ def config():
                     choices=['all', 'pointcloud', 'orthophoto', 'dem'],
                     help=('Choose what to merge in the merge step in a split dataset. '
                           'By default all available outputs are merged. '
-                          'Default: '
+                          'Options: %(choices)s. Default: '
                             '%(default)s'))
 
     args = parser.parse_args()

--- a/opendm/config.py
+++ b/opendm/config.py
@@ -55,10 +55,6 @@ parser = SettingsParser(description='OpenDroneMap',
                         yaml_file=open(context.settings_path))
 
 def config():
-    parser.add_argument('--images', '-i',
-                        metavar='<path>',
-                        help='Path to input images'),
-
     parser.add_argument('--project-path',
                         metavar='<path>',
                         help='Path to the project folder')

--- a/opendm/types.py
+++ b/opendm/types.py
@@ -220,13 +220,10 @@ class ODM_GeoRef(object):
 
 
 class ODM_Tree(object):
-    def __init__(self, root_path, images_path, gcp_file = None):
+    def __init__(self, root_path, gcp_file = None):
         # root path to the project
         self.root_path = io.absolute_path_file(root_path)
-        if not images_path:
-            self.input_images = io.join_paths(self.root_path, 'images')
-        else:
-            self.input_images = io.absolute_path_file(images_path)
+        self.input_images = io.join_paths(self.root_path, 'images')
 
         # modules paths
 

--- a/stages/dataset.py
+++ b/stages/dataset.py
@@ -39,7 +39,7 @@ def load_images_database(database_file):
 class ODMLoadDatasetStage(types.ODM_Stage):
     def process(self, args, outputs):
         # Load tree
-        tree = types.ODM_Tree(args.project_path, args.images, args.gcp)
+        tree = types.ODM_Tree(args.project_path, args.gcp)
         outputs['tree'] = tree
 
         if args.time and io.file_exists(tree.benchmarking):


### PR DESCRIPTION
Images are expected to be in `project-path/images`. Specifying any other folder can break other parts of the pipeline and I'm not even sure this is used by anyone. Simplifies things.