### PR TITLE
Support for spaces in the project path 

### DIFF
--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -17,7 +17,7 @@ class OSFMContext:
         self.opensfm_project_path = opensfm_project_path
     
     def run(self, command):
-        system.run('%s/bin/opensfm %s %s' %
+        system.run('%s/bin/opensfm %s "%s"' %
                     (context.opensfm_path, command, self.opensfm_project_path))
 
     def export_bundler(self, destination_bundle_file, rerun=False):

--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -23,7 +23,7 @@ class OSFMContext:
     def export_bundler(self, destination_bundle_file, rerun=False):
         if not io.file_exists(destination_bundle_file) or rerun:
                 # convert back to bundler's format
-                system.run('%s/bin/export_bundler %s' %
+                system.run('%s/bin/export_bundler "%s"' %
                         (context.opensfm_path, self.opensfm_project_path))
         else:
             log.ODM_WARNING('Found a valid Bundler file in: %s' % destination_bundle_file)

--- a/stages/mve.py
+++ b/stages/mve.py
@@ -119,7 +119,7 @@ class ODMMveStage(types.ODM_Stage):
             retry_count = 1
             while retry_count < 10:
                 try:
-                    system.run('%s %s %s' % (context.dmrecon_path, ' '.join(dmrecon_config), tree.mve), env_vars={'OMP_NUM_THREADS': args.max_concurrency})
+                    system.run('%s "%s" "%s"' % (context.dmrecon_path, ' '.join(dmrecon_config), tree.mve), env_vars={'OMP_NUM_THREADS': args.max_concurrency})
                     break
                 except Exception as e:
                     if str(e) == "Child returned 134" or str(e) == "Child returned 1":

--- a/stages/mve.py
+++ b/stages/mve.py
@@ -42,7 +42,7 @@ class ODMMveStage(types.ODM_Stage):
 
             # run mve makescene
             if not io.dir_exists(tree.mve_views):
-                system.run('%s %s %s' % (context.makescene_path, tree.mve_path, tree.mve), env_vars={'OMP_NUM_THREADS': args.max_concurrency})
+                system.run('%s "%s" "%s"' % (context.makescene_path, tree.mve_path, tree.mve), env_vars={'OMP_NUM_THREADS': args.max_concurrency})
 
             self.update_progress(10)
 


### PR DESCRIPTION
This PR fixes problem when project path contains white characters. Fixed invocations of:
 - opensfm
 - export bundler
 - mve makescene
 - mve dense reconstruction

Fixes #1006 