### PR TITLE
Add force-gps flag

### DIFF
--- a/docker.settings.yaml
+++ b/docker.settings.yaml
@@ -61,3 +61,4 @@ project_path: '/' #DO NOT CHANGE THIS OR DOCKER WILL NOT WORK. It should be '/'
 #orthophoto_bigtiff: IF_SAFER # Options are [YES, NO, IF_NEEDED, IF_SAFER]
 #build_overviews: FALSE
 #pc-classify: none
+#force_gps: False

--- a/opendm/config.py
+++ b/opendm/config.py
@@ -574,6 +574,12 @@ def config():
                           'Options: %(choices)s. Default: '
                             '%(default)s'))
 
+    parser.add_argument('--force-gps',
+                    action='store_true',
+                    default=False,
+                    help=('Use images\' gps exif data for reconstruction, even if there are gcps present.'
+                          'This flag is useful if you have high precision gps measurements.'))
+
     args = parser.parse_args()
 
     # check that the project path setting has been set properly

--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -133,7 +133,8 @@ class OSFMContext:
 
             if gcp_path:
                 config.append("bundle_use_gcp: yes")
-                config.append("bundle_use_gps: no")
+                if not args.force_gps:
+                    config.append("bundle_use_gps: no")
                 io.copy(gcp_path, self.path("gcp_list.txt"))
             
             config = config + append_config

--- a/settings.yaml
+++ b/settings.yaml
@@ -61,3 +61,4 @@ project_path:  '' # Example: '/home/user/ODMProjects'
 #orthophoto_bigtiff: IF_SAFER # Options are [YES, NO, IF_NEEDED, IF_SAFER]
 #build_overviews: FALSE
 #pc-classify: none
+#force_gps: False


### PR DESCRIPTION
Based on [this](https://community.opendronemap.org/t/how-to-use-high-precision-images-together-with-gcps/2618) forum post.

**Context**
We currently have high precision gps that we add to the images' exif tags. We want to make sure that OpenSFM uses this information, even if we also used GCPs. 

Per @pierotofy 's recommendation, we want to add a flag that allows us to use both GCPs and the images' gps for the reconstruction.

Let me know if you have any other questions :)