### PR TITLE
Added --pc-sample

### DIFF
--- a/opendm/config.py
+++ b/opendm/config.py
@@ -320,6 +320,14 @@ def config():
                         help='Filters the point cloud by removing points that deviate more than N standard deviations from the local mean. Set to 0 to disable filtering.'
                              '\nDefault: '
                              '%(default)s')
+    
+    parser.add_argument('--pc-sample',
+                        metavar='<positive float>',
+                        type=float,
+                        default=0,
+                        help='Filters the point cloud by keeping only a single point around a radius N (in meters). This can be useful to limit the output resolution of the point cloud. Set to 0 to disable sampling.'
+                             '\nDefault: '
+                             '%(default)s')
 
     parser.add_argument('--smrf-scalar',
                         metavar='<positive float>',

--- a/opendm/point_cloud.py
+++ b/opendm/point_cloud.py
@@ -4,17 +4,22 @@ from opendm import log
 from opendm import context
 from opendm.system import run
 
-def filter(input_point_cloud, output_point_cloud, standard_deviation=2.5, meank=16, confidence=None, verbose=False):
+def filter(input_point_cloud, output_point_cloud, standard_deviation=2.5, meank=16, confidence=None, sample_radius=0, verbose=False):
     """
     Filters a point cloud
     """
-    if standard_deviation <= 0 or meank <= 0:
+    if (standard_deviation <= 0 or meank <= 0) and sample_radius <= 0:
         log.ODM_INFO("Skipping point cloud filtering")
         return
 
-    log.ODM_INFO("Filtering point cloud (statistical, meanK {}, standard deviation {})".format(meank, standard_deviation))
+    if standard_deviation > 0 and meank > 0:
+        log.ODM_INFO("Filtering point cloud (statistical, meanK {}, standard deviation {})".format(meank, standard_deviation))
+    
     if confidence:
         log.ODM_INFO("Keeping only points with > %s confidence" % confidence)
+
+    if sample_radius > 0:
+        log.ODM_INFO("Sampling points around a %sm radius" % sample_radius)
 
     if not os.path.exists(input_point_cloud):
         log.ODM_ERROR("{} does not exist, cannot filter point cloud. The program will now exit.".format(input_point_cloud))
@@ -34,12 +39,15 @@ def filter(input_point_cloud, output_point_cloud, standard_deviation=2.5, meank=
       'meank': meank,
       'verbose': '-verbose' if verbose else '',
       'confidence': '-confidence %s' % confidence if confidence else '',
+      'sample': max(0, sample_radius)
     }
 
     system.run('{bin} -inputFile {inputFile} '
          '-outputFile {outputFile} '
          '-sd {sd} '
-         '-meank {meank} {confidence} {verbose} '.format(**filterArgs))
+         '-meank {meank} '
+         '-sample {sample} '
+         '{confidence} {verbose} '.format(**filterArgs))
 
     # Remove input file, swap temp file
     if not os.path.exists(output_point_cloud):

--- a/stages/odm_filterpoints.py
+++ b/stages/odm_filterpoints.py
@@ -23,7 +23,11 @@ class ODMFilterPoints(types.ODM_Stage):
             else:
                 inputPointCloud = tree.mve_model
 
-            point_cloud.filter(inputPointCloud, tree.filtered_point_cloud, standard_deviation=args.pc_filter, confidence=None, verbose=args.verbose)
+            point_cloud.filter(inputPointCloud, tree.filtered_point_cloud, 
+                                standard_deviation=args.pc_filter, 
+                                confidence=None, 
+                                sample_radius=args.pc_sample,
+                                verbose=args.verbose)
         else:
             log.ODM_WARNING('Found a valid point cloud file in: %s' %
                             tree.filtered_point_cloud)


### PR DESCRIPTION
This PR adds a `--pc-sample` flag which allows users to effectively control the output resolution of the point cloud. This can be useful for speeding up processing in later stages of the pipeline and to delete points that might be overlapping.

Default behavior is to keep the point cloud at full resolution (no breaking changes).