### PR TITLE
Use DSM's euclidean map for DTM merging

### DIFF
--- a/opendm/io.py
+++ b/opendm/io.py
@@ -58,7 +58,7 @@ def find(filename, folder):
         return '/'.join((root, filename)) if filename in files else None
 
 
-def related_file_path(input_file_path, prefix="", postfix=""):
+def related_file_path(input_file_path, prefix="", postfix="", replace_base=None):
     """
     For example: related_file_path("/path/to/file.ext", "a.", ".b")
      --> "/path/to/a.file.b.ext"
@@ -71,6 +71,9 @@ def related_file_path(input_file_path, prefix="", postfix=""):
     basename, ext = os.path.splitext(filename)
     # basename = file
     # ext = .ext
+
+    if replace_base is not None:
+        basename = replace_base
 
     return os.path.join(path, "{}{}{}{}".format(prefix, basename, postfix, ext))
 

--- a/stages/odm_dem.py
+++ b/stages/odm_dem.py
@@ -58,7 +58,8 @@ class ODMDEMStage(types.ODM_Stage):
                 self.rerun():
 
                 products = []
-                if args.dsm: products.append('dsm')
+
+                if args.dsm or (args.dtm and args.dem_euclidean_map): products.append('dsm')
                 if args.dtm: products.append('dtm')
                 
                 resolution = gsd.cap_resolution(args.dem_resolution, tree.opensfm_reconstruction, gsd_error_estimate=-3, ignore_gsd=args.ignore_gsd)

--- a/stages/splitmerge.py
+++ b/stages/splitmerge.py
@@ -314,7 +314,14 @@ class ODMMergeStage(types.ODM_Stage):
                     
                     # Merge
                     dem_vars = utils.get_dem_vars(args)
-                    euclidean_merge_dems(all_dems, dem_file, dem_vars)
+                    eu_map_source = None # Default
+
+                    # Use DSM's euclidean map for DTMs
+                    # (requires the DSM to be computed)
+                    if human_name == "DTM":
+                        eu_map_source = "dsm"
+
+                    euclidean_merge_dems(all_dems, dem_file, dem_vars, euclidean_map_source=eu_map_source)
 
                     if io.file_exists(dem_file):
                         # Crop


### PR DESCRIPTION
Improves DTM merging by using the DSM euclidean map, performing NN interpolation in areas where rasters overlap but have no direct elevation values.