### PR TITLE
SIFT features

### DIFF
--- a/SuperBuild/cmake/External-OpenCV.cmake
+++ b/SuperBuild/cmake/External-OpenCV.cmake
@@ -1,7 +1,29 @@
 set(_proj_name opencv)
 set(_SB_BINARY_DIR "${SB_BINARY_DIR}/${_proj_name}")
 
+ExternalProject_Add(opencv_contrib
+  PREFIX            ${_SB_BINARY_DIR}
+  TMP_DIR           ${_SB_BINARY_DIR}/tmp
+  STAMP_DIR         ${_SB_BINARY_DIR}/stamp
+  #--Download step--------------
+  DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
+  URL               https://github.com/pierotofy/opencv_contrib/archive/346sift.zip
+  #--Update/Patch step----------
+  UPDATE_COMMAND    ""
+  #--Configure step-------------
+  SOURCE_DIR        ${SB_SOURCE_DIR}/opencv_contrib
+  CONFIGURE_COMMAND ""
+  BUILD_IN_SOURCE 1
+  BUILD_COMMAND   ""
+  INSTALL_COMMAND ""
+  #--Output logging-------------
+  LOG_DOWNLOAD      OFF
+  LOG_CONFIGURE     OFF
+  LOG_BUILD         OFF
+)
+
 ExternalProject_Add(${_proj_name}
+  DEPENDS           opencv_contrib
   PREFIX            ${_SB_BINARY_DIR}
   TMP_DIR           ${_SB_BINARY_DIR}/tmp
   STAMP_DIR         ${_SB_BINARY_DIR}/stamp
@@ -46,6 +68,8 @@ ExternalProject_Add(${_proj_name}
     -DBUILD_opencv_java=OFF
     -DBUILD_opencv_ocl=OFF
     -DBUILD_opencv_ts=OFF
+    -DOPENCV_EXTRA_MODULES_PATH=${SB_SOURCE_DIR}/opencv_contrib/modules
+    -DBUILD_opencv_xfeatures2d=ON
     -DCMAKE_BUILD_TYPE:STRING=Release
     -DCMAKE_INSTALL_PREFIX:PATH=${SB_INSTALL_DIR}
   #--Build step-----------------

--- a/opendm/config.py
+++ b/opendm/config.py
@@ -249,7 +249,7 @@ def config():
 
     parser.add_argument('--mesh-octree-depth',
                         metavar='<positive integer>',
-                        default=11,
+                        default=10,
                         type=int,
                         help=('Oct-tree depth used in the mesh reconstruction, '
                               'increase to get more vertices, recommended '

--- a/opendm/config.py
+++ b/opendm/config.py
@@ -113,6 +113,14 @@ def config():
                         help=('Minimum number of features to extract per image. '
                               'More features leads to better results but slower '
                               'execution. Default: %(default)s'))
+    
+    parser.add_argument('--feature-type',
+            metavar='<string>',
+            default='sift',
+            choices=['sift', 'hahog'],
+            help=('Choose the algorithm for extracting keypoints and computing descriptors. '
+                'Can be one of: [sift, hahog]. Default: '
+                '%(default)s'))
 
     parser.add_argument('--matcher-neighbors',
                         type=int,

--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -104,6 +104,7 @@ class OSFMContext:
             # create config file for OpenSfM
             config = [
                 "use_exif_size: no",
+                "feature_type: SIFT",
                 "feature_process_size: %s" % args.resize_to,
                 "feature_min_frames: %s" % args.min_num_features,
                 "processes: %s" % args.max_concurrency,

--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -93,6 +93,7 @@ class OSFMContext:
                     log.ODM_WARNING("Cannot set camera_models_overrides.json: %s" % str(e))
 
             use_bow = False
+            feature_type = "SIFT"
 
             matcher_neighbors = args.matcher_neighbors
             if matcher_neighbors != 0 and reconstruction.multi_camera is not None:
@@ -104,7 +105,6 @@ class OSFMContext:
             # create config file for OpenSfM
             config = [
                 "use_exif_size: no",
-                "feature_type: SIFT",
                 "feature_process_size: %s" % args.resize_to,
                 "feature_min_frames: %s" % args.min_num_features,
                 "processes: %s" % args.max_concurrency,
@@ -129,8 +129,17 @@ class OSFMContext:
                 log.ODM_INFO("No GPS information, using BOW matching")
                 use_bow = True
 
+            feature_type = args.feature_type.upper()
+
             if use_bow:
                 config.append("matcher_type: WORDS")
+
+                # Cannot use SIFT with BOW
+                if feature_type == "SIFT":
+                    log.ODM_WARNING("Using BOW matching, will use HAHOG feature type, not SIFT")
+                    feature_type = "HAHOG"
+            
+            config.append("feature_type: %s" % feature_type)
 
             if has_alt:
                 log.ODM_INFO("Altitude data detected, enabling it for GPS alignment")


### PR DESCRIPTION
This PR adds support for a new option `--feature-type` which allows to select the feature extraction algorithm `SIFT` or `HAHOG` (current default).

SIFT is patented until `March 7th 2020`, so code in this PR should be used only for research purposes.

The OpenCV contrib modules has been stripped to include only the relevant SIFT code (other nonfree modules have been removed).

Do not merge prior to March 7th.