### PR TITLE
Updated dockefiles to best practices ready for multi stage builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,15 @@ odm_meshing
 odm_georeferencing
 images_resize
 .git
+
+/contrib
+/docs
+/hooks
+/img
+/license
+/tests
+tests.sh
+settings.yml
+code_of_conduct.md
+configure_18_04.sh
+index.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,13 @@
-FROM phusion/baseimage
+FROM phusion/baseimage as base
 
 # Env variables
 ENV DEBIAN_FRONTEND noninteractive
 
 #Install dependencies and required requisites
-RUN apt-get update -y \
-  && apt-get install -y \
-    software-properties-common \
-  && add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable \
+RUN add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable \
   && add-apt-repository -y ppa:george-edison55/cmake-3.x \
-  && apt-get update -y
-
-# All packages (Will install much faster)
-RUN apt-get install --no-install-recommends -y \
+  && apt-get update -y \
+  && apt-get install --no-install-recommends -y \
   build-essential \
   cmake \
   gdal-bin \
@@ -53,41 +48,30 @@ RUN apt-get install --no-install-recommends -y \
   python-pip \
   python-software-properties \
   python-wheel \
+  software-properties-common \
   swig2.0 \
   grass-core \
-  libssl-dev
+  libssl-dev \
+  && apt-get remove libdc1394-22-dev \
+  && pip install --upgrade pip \
+  && pip install setuptools
 
-RUN apt-get remove libdc1394-22-dev
-RUN pip install --upgrade pip
-RUN pip install setuptools
 
 # Prepare directories
-RUN mkdir /code
 WORKDIR /code
 
-# Copy repository files
-COPY CMakeLists.txt /code/CMakeLists.txt
-COPY configure.sh /code/configure.sh
-COPY /modules/ /code/modules/
-COPY /opendm/ /code/opendm/
-COPY run.py /code/run.py
-COPY run.sh /code/run.sh
-COPY /stages/ /code/stages/
-COPY /SuperBuild/cmake/ /code/SuperBuild/cmake/
-COPY /SuperBuild/CMakeLists.txt /code/SuperBuild/CMakeLists.txt
-COPY docker.settings.yaml /code/settings.yaml
-COPY VERSION /code/VERSION
-COPY requirements.txt /code/requirements.txt
+# Copy everything
+COPY . ./
 
 RUN pip install -r requirements.txt
-RUN pip install --upgrade cryptography && python -m easy_install --upgrade pyOpenSSL
 
 ENV PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python2.7/dist-packages"
 ENV PYTHONPATH="$PYTHONPATH:/code/SuperBuild/src/opensfm"
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib"
 
 # Compile code in SuperBuild and root directories
-RUN cd SuperBuild \
+RUN rm -fr docker \
+  && cd SuperBuild \
   && mkdir build \
   && cd build \
   && cmake .. \
@@ -99,7 +83,8 @@ RUN cd SuperBuild \
   && make -j$(nproc)
 
 # Cleanup APT
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
+RUN apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
 
 # Clean Superbuild
 RUN rm -rf \
@@ -114,4 +99,3 @@ RUN rm -rf \
 
 # Entry point
 ENTRYPOINT ["python", "/code/run.py"]
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ pyproj==2.2.2
 psutil==5.6.3
 joblib==0.13.2
 Fiona==1.8.9.post2
+cryptography==2.8
+pyOpenSSL==19.1.0


### PR DESCRIPTION
I am wanting to get the docker images to be much smaller to make the update/download process quicker. The first step is to make the docker files inline with the docker best practices: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/ 