### PR TITLE
Update sample value / units for orthophoto_resolution in settings.yaml

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -55,7 +55,7 @@ project_path: '/' # Example: '/home/user/ODMProjects'
 #dem-approximate: False
 #dem-decimation: 1
 #dem-terrain-type: ComplexForest
-#orthophoto_resolution: 20.0 # Pixels/meter
+#orthophoto_resolution: 5.0 # cm/pixel
 #orthophoto_target_srs: !!null # Currently does nothing
 #orthophoto_no_tiled: False
 #orthophoto_compression: DEFLATE # Options are [JPEG, LZW, PACKBITS, DEFLATE, LZMA, NONE] Don't change unless you know what you are doing


### PR DESCRIPTION
## Problem
ODM allows the user to set `--orthophoto-resolution <float>` as a CLI parameter. The documentation states that the unit and default value for this parameter should be `5.0 cm / pixel`:
```
--orthophoto-resolution <float > 0.0>
                      Orthophoto resolution in cm / pixel.
                                              Default: 5
```

The example  `settings.yaml` provides a different default value and unit:
```
#orthophoto_resolution: 20.0 # Pixels/meter
```

This was rather misleading to a beginner ODM user like myself.

## Approach
After some experimentation, I was able to confirm (at least in 0.9.8) that lowering this value would actually increases the resolution. If the value were really `pixels/meter`, then increasing the value would increase the resolution.

Update the value / units in the `settings.yaml` to match the documentation, as this appears to be an accurate description for this parameter:
```
#orthophoto_resolution: 5.0 # cm/pixel
```

NOTE: there are two other references to [`pixels/meter`](https://github.com/OpenDroneMap/ODM/search?q=pixels%2Fmeter&unscoped_q=pixels%2Fmeter), but these appears to be in lower level C libraries and I was unsure if those comments should be changed to reflect the new units.

* https://github.com/OpenDroneMap/ODM/blob/v0.9.8/modules/odm_orthophoto/src/OdmOrthoPhoto.hpp#L182
* https://github.com/OpenDroneMap/ODM/blob/v0.9.8/modules/odm_orthophoto/src/OdmOrthoPhoto.cpp#L96
* https://github.com/OpenDroneMap/ODM/blob/v0.9.8/modules/odm_orthophoto/src/OdmOrthoPhoto.cpp#L209-L210