### PR TITLE
Recreate splits after reconstruction

### DIFF
--- a/opendm/config.py
+++ b/opendm/config.py
@@ -674,6 +674,12 @@ def config(argv=None):
                         'are added to the cluster. This is done to ensure '
                         'that neighboring submodels overlap.')
 
+    parser.add_argument('--split-multitracks',
+                       action=StoreTrue,
+                       nargs=0,
+                       default=False,
+                       help='Split multi-track reconstructions.')
+
     parser.add_argument('--sm-cluster',
                         metavar='<string>',
                         action=StoreValue,


### PR DESCRIPTION
Adapted from discussion in #1076 

In short, after reconstruction finishes, this PR will ensure each split only has a single reconstruction track by regenerating the splits.  Without this PR, additional tracks in a reconstruction are dropped as part of the track exports and point cloud generation, resulting in possibly lost areas of a map if large secondary tracks are generated in a split.

I didn't have everything available to test this outside docker, so I'd appreciate if someone could help me out testing this before we merge. It's also possible that there's more ODM oriented APIs for handling some of the file management, so there may be some style issues.

For future work, the resulting set could probably be optimized by discarding any tracks whose images are fully contained in another, longer track. 
Additionally, you could probably get better results if a full bundle adjustment could be done on the resulting reconstruction data at the alignment stage rather than just the current similarity transform, since the multiple tracks may be an indication that the initial split was not ideal for the current dataset. I've noticed some issues relating to this where a track is misaligned on the vertical axis, but this seems common with small split datasets and low overlaps, so your mileage may vary.