### PR TITLE
Better support for RTK

### DIFF
--- a/opendm/config.py
+++ b/opendm/config.py
@@ -707,6 +707,17 @@ def config(argv=None):
                     help=('Use images\' GPS exif data for reconstruction, even if there are GCPs present.'
                           'This flag is useful if you have high precision GPS measurements. '
                           'If there are no GCPs, this flag does nothing. Default: %(default)s'))
+    
+    parser.add_argument('--gps-accuracy',
+                        type=float,
+                        action=StoreValue,
+                        metavar='<positive float>',
+                        default=15,
+                        help='Set a value in meters for the GPS Dilution of Precision (DOP) '
+                        'information for all images. If your images are tagged '
+                        'with high precision GPS information (RTK), this value will be automatically '
+                        'set accordingly. You can use this option to manually set it in case the reconstruction '
+                        'fails. Lowering this option can sometimes help control bowling-effects over large areas. Default: %(default)s')
 
     parser.add_argument('--optimize-disk-space',
                 action=StoreTrue,

--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -259,7 +259,6 @@ class ODM_Photo:
 
         if xmp_start < xmp_end:
             xmp_str = img_str[xmp_start:xmp_end + 12]
-            xmp_str = xmp_str.replace("rdf:about=''xmlns", "rdf:about='' xmlns")
             xdict = x2d.parse(xmp_str)
             xdict = xdict.get('x:xmpmeta', {})
             xdict = xdict.get('rdf:RDF', {})


### PR DESCRIPTION
This PR adds support for RTK tags to constraint bundle adjustment and increase accuracy of georeferencing and reconstruction by overriding the GPS DOP values.

![anim](https://user-images.githubusercontent.com/1951843/80835283-7029f100-8bc0-11ea-8e7f-fbde67cc9228.gif)

Should work with Phantom 4 RTK (proprietary DJI tags) and several other cameras that use the more common `Camera:GPSXYAccuracy` and `Camera:GPSZAccuracy` tags.

Also allows users to override GPS DOP values (cc @smathermather), so no more exiftool magic needed.