### PR TITLE
Fix pip requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML==3.13
 ExifRead==2.1.2
-cloudpickle==0.4.0
+cloudpickle==1.2.2
 pytz==2020.1
 gpxpy==1.3.5
 xmltodict==0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 PyYAML==3.13
 ExifRead==2.1.2
+cloudpickle==0.4.0
+pytz==2020.1
 gpxpy==1.3.5
 xmltodict==0.12.0
 appsettings==0.8


### PR DESCRIPTION
Fixes installation of ODM in certain native environments, preventing https://community.opendronemap.org/t/process-exited-with-code-1-and-no-module-named-pytz/3946/5 and another issue related to cloudpickle.

We really need to get #1066 going.