### PR TITLE
Handles malformed XMP XML

### DIFF
--- a/SuperBuild/cmake/External-OpenSfM.cmake
+++ b/SuperBuild/cmake/External-OpenSfM.cmake
@@ -9,7 +9,7 @@ ExternalProject_Add(${_proj_name}
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
   GIT_REPOSITORY    https://github.com/OpenDroneMap/OpenSfM/
-  GIT_TAG           099
+  GIT_TAG           100
   #--Update/Patch step----------
   UPDATE_COMMAND    git submodule update --init --recursive
   #--Configure step-------------

--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -270,7 +270,7 @@ class ODM_Photo:
             xmp_str = img_str[xmp_start:xmp_end + 12]
             try:
                 xdict = x2d.parse(xmp_str)
-            except ExpatError as e:
+            except ExpatError:
                 from bs4 import BeautifulSoup
                 xmp_str = str(BeautifulSoup(xmp_str, 'xml'))
                 xdict = x2d.parse(xmp_str)

--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -12,7 +12,7 @@ import log
 import system
 import xmltodict as x2d
 from opendm import get_image_size
-
+from xml.parsers.expat import ExpatError
 
 class ODM_Photo:
     """   ODMPhoto - a class for ODMPhotos
@@ -205,10 +205,12 @@ class ODM_Photo:
                             self.gps_z_stddev = float(self.get_xmp_tag(tags, '@drone-dji:RtkStdHgt'))
                     else:
                         self.set_attr_from_xmp_tag('gps_xy_stddev', tags, [
-                            '@Camera:GPSXYAccuracy'
+                            '@Camera:GPSXYAccuracy',
+                            'GPSXYAccuracy'
                         ], float)
                         self.set_attr_from_xmp_tag('gps_z_stddev', tags, [
-                            '@Camera:GPSZAccuracy'
+                            '@Camera:GPSZAccuracy',
+                            'GPSZAccuracy'
                         ], float)
 
                     if 'DLS:Yaw' in tags:
@@ -227,7 +229,6 @@ class ODM_Photo:
                 # ], float)
             
         self.width, self.height = get_image_size.get_image_size(_path_file)
-
         # Sanitize band name since we use it in folder paths
         self.band_name = re.sub('[^A-Za-z0-9]+', '', self.band_name)
 
@@ -267,7 +268,13 @@ class ODM_Photo:
 
         if xmp_start < xmp_end:
             xmp_str = img_str[xmp_start:xmp_end + 12]
-            xdict = x2d.parse(xmp_str)
+            try:
+                xdict = x2d.parse(xmp_str)
+            except ExpatError as e:
+                from bs4 import BeautifulSoup
+                xmp_str = str(BeautifulSoup(xmp_str, 'xml'))
+                xdict = x2d.parse(xmp_str)
+                log.ODM_WARNING("%s has malformed XMP XML (but we fixed it)" % self.filename)
             xdict = xdict.get('x:xmpmeta', {})
             xdict = xdict.get('rdf:RDF', {})
             xdict = xdict.get('rdf:Description', {})

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,5 @@ cryptography==2.8
 pyOpenSSL==19.1.0
 scikit-learn==0.20
 laspy==1.6.0
+beautifulsoup4==4.9.1
+lxml==4.5.1


### PR DESCRIPTION
Some cameras have invalid/malformed XML in the XMP section.

This PR adds support for attempting to automatically fix malformed XMP sections (includes code from https://github.com/mapillary/OpenSfM/pull/612 ).