### PR TITLE
Use KDTREE flann algorithm by default

### DIFF
--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -135,6 +135,7 @@ class OSFMContext:
             # create config file for OpenSfM
             config = [
                 "use_exif_size: no",
+                "flann_algorithm": "KDTREE", # more stable, faster than KMEANS
                 "feature_process_size: %s" % args.resize_to,
                 "feature_min_frames: %s" % args.min_num_features,
                 "processes: %s" % args.max_concurrency,


### PR DESCRIPTION
Sets the default FLANN algorithm for KDTREE. This algorithm seems more stable and faster for certain datasets.

Related: https://github.com/mapillary/OpenSfM/pull/614