### PR TITLE
Sequoia script changes

### DIFF
--- a/contrib/sequoia/README.md
+++ b/contrib/sequoia/README.md
@@ -2,12 +2,25 @@
 
 The Sequoia captures five images per shot, an RGB JPG and four single band TIFs, but only the JPG contains GPS Exif tags. To use the single-band TIFs for multispectral mapping/analysis it’s useful (not technically required) to have them also contain GPS Exif tags.
 
-This script will copy the GPS Exif tags from the RGB JPG file to the four TIFs of the same shot.
+## prepare-tifs.sh
 
-## Requirements
+This script will copy the GPS Exif tags from the RGB JPG file to the four TIFs of the same shot. It will process all images in the working directory and use the sequence number in the filename to match JPG to TIFs. Therefore it *must* only be applied to one folder from the Sequoia per run.
+
+### Requirements
 * [exiv2](https://www.exiv2.org/)
+* bash (tested in git-bash on Windows, other shells probably work too)
 
-## Usage
+### Usage
+Run the script from a directory of images captured by Sequoia.
+```
+./prepare-tifs.sh
+```
+
+## subfolder-per-band.sh
+
+This script will move images into a subfolder per band.
+
+### Usage
 Run the script from a directory of images captured by Sequoia.
 ```
 ./prepare-tifs.sh

--- a/contrib/sequoia/prepare-tifs.sh
+++ b/contrib/sequoia/prepare-tifs.sh
@@ -1,23 +1,15 @@
 #!/bin/sh
 
-# Rename - remove timestamp
-for img in IMG_*.*; do
-	newname=`echo $img | sed -r "s/IMG_[0-9]+_[0-9]+_//"`
-	mv $img $newname
-done
+# Copy GPS Exif tags from IMG_*_RGB.JPG to .TIF images
 
-# Copy GPS Exif tags from *RGB.JPG to .TIF images
-for rgb in *_RGB.JPG; do
+for rgb in IMG_*_RGB.JPG; do
+	seqnum=`echo $rgb | sed -r "s/IMG_[0-9]+_[0-9]+_([0-9]+).*/\1/"`
+	echo $seqnum
+	exiv2 -PEVk --grep GPS $rgb > $rgb.tags
+
 	for band in GRE NIR RED REG; do
-		tif=`echo $rgb | sed s/_RGB.JPG/_$band.TIF/`
-		exiv2 -PEVk --grep GPS $rgb > $rgb.tags
-		exiv2 -m $rgb.tags $tif
-		rm $rgb.tags
+		exiv2 -m $rgb.tags IMG_*_$seqnum\_$band.TIF
 	done
-done
 
-# Move into subfolder per band
-for band in RGB GRE NIR RED REG; do
-	mkdir $band
-	mv *_$band.* $band/
+	rm $rgb.tags
 done

--- a/contrib/sequoia/subfolder-per-band.sh
+++ b/contrib/sequoia/subfolder-per-band.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Move into subfolder per band
+for band in RGB GRE NIR RED REG; do
+	mkdir $band
+	mv IMG_*_$band.* $band/
+done


### PR DESCRIPTION
- Leave filenames unchanged
- Separate script for moving images into subfolder pre band
- Update README.md
- Scripts marked executable

I realised that by changing the filenames to just the sequence number it was going to cause problems if I want to upload the images from multiple flights.  Now it leaves the filenames as they are, but still only uses the sequence number to match the JPG to the TIFs (the timestamps don't always match).