### PR TITLE
updating docker files to pull from phusion/baseimage:0.10.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage as base
+FROM phusion/baseimage:0.10.2 as base
 
 # Env variables
 ENV DEBIAN_FRONTEND noninteractive

--- a/portable.Dockerfile
+++ b/portable.Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage as base
+FROM phusion/baseimage:0.10.2 as base
 
 # Env variables
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
fix issue #1148

use explicit docker image tag pointing to the latest `phusion/baseimage` release built with ubuntu 16.04

useful to everyone interested in building their own docker images with the latest ODM version from GitHub :)