### PR TITLE
fix #1151 - check for symbolic links before removing directories in run_opensfm.py

### DIFF
--- a/stages/run_opensfm.py
+++ b/stages/run_opensfm.py
@@ -34,10 +34,12 @@ class ODMOpenSfMStage(types.ODM_Stage):
         self.update_progress(70)
 
         if args.optimize_disk_space:
-            shutil.rmtree(octx.path("features"))
-            shutil.rmtree(octx.path("matches"))
-            shutil.rmtree(octx.path("exif"))
-            shutil.rmtree(octx.path("reports"))
+            for folder in ["features", "matches", "exif", "reports"]:
+                folder_path = octx.path(folder)
+                if os.path.islink(folder_path):
+                    os.unlink(folder_path)
+                else:
+                    shutil.rmtree(folder_path)
 
         # If we find a special flag file for split/merge we stop right here
         if os.path.exists(octx.path("split_merge_stop_at_reconstruction.txt")):


### PR DESCRIPTION
Changed the openfsm calls from python to check if directories are `symlinks`  before removing them and applying the correct method for removing symbolic links or actual directories. This allows running ODM with `--split` and `--optimize-disk-space` flags in conjunction.