### PR TITLE
CoC deleted

### DIFF
--- a/CONTACT.md
+++ b/CONTACT.md
@@ -1,0 +1,5 @@
+Welcome to the OpenDroneMap community
+
+Accept and offer criticism constructively. Let anyone have their desired privacy.
+Settle differences within these boundaries.
+Finding yourself unable to do so, create an issue and tag @smathermather, the project founder.

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,1 +1,0 @@
-See https://github.com/OpenDroneMap/documents/blob/master/CONDUCT.md


### PR DESCRIPTION
Following my rather unconstructive rant, and the laudable follow-up here https://github.com/OpenDroneMap/ODM/issues/1102#issuecomment-673211001
I thought I'd put my constructive side to use.

The main promise of the Covenant CoC is to somehow attain a functional defence from its stated intolerances, through no further action. There is a system of reactions, but it isn't beyond the recourse of the benevolent dictator. Neither system is perfect, and it may seem redundant to bestow these powers onto "Project maintainers", because it doesn't really change anything in practice so much as in the sound of things.
The actual law of the land is further laid out in https://github.com/OpenDroneMap/documents/blob/master/GOVERNANCE.md "[Who decides stuff](https://github.com/OpenDroneMap/documents/commit/d2be7b78ef751f0cfb5c5022029da66f8b6c74ef)?" It is not a "final governance model", sure. However, is that a good or a bad thing, considering? Is that not what we are dealing with anyhow? If honest about that onto ourselves, why not the projected outside world?
I should think nobody has to agree, and that a further nobody would take offence. I could be wrong.

To deal with what is in https://github.com/OpenDroneMap/documents/blob/master/CONDUCT.md

It starts out _stating_ respect for people (?), further qualifying this into who they are in the project as contributors. Fine?
While perhaps an unintended hard-line meritocracy, does respect actually need saying in any system not in need of having it pointed out? The further qualifying is where those two points are driven home; Are users even in "other activities". Would it then be the case that respect isn't to be assumed in projects that don't have this? I should think not.
> As contributors and maintainers, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.

Is there any respect to be had for people that don't contribute? Not necessarily. X)

We then get into the further division of people into what would otherwise be arbitrary groups, for what reason I can only imagine is OpenDroneMap really needing to tell its contributors what is OK and what is not. I can't really say the topics cast a very positive light on the imposition of it otherwise happening more often, on what are a group of contributors I imagine didn't get asked in the first place. So the pledge isn't a pledge(?), and the document is inserted into the project after its creation after the fact, when its function was achieved already.
Is this ever not the case? Not because there was an issue(?), but because it supposedly avoids them. The dots emphasize the disconnects…

Now lets say someone has had or doesn't a problem in any of these categories. Is there some exposure therapy in being subjected to how much of an issue it could possibly be, in so many places in the libre software community? Is there a great problem here, out of any place in the world, and is there a problem in projects that don't have this? If this is even part of the libre software community, isn't that part where problems are to be found, and from which they stem?
Otherwise I should think before and after this neither is how to deal with problems, nor is removing people and history something any of the involved people learn anything but resentment and fear from. What hopes does that have of fixing anything in the greater sense. At best it means it doesn't happen in a smaller part of the community, but is free to play out elsewhere.

In this routing of the electron by the switch, the user has followed a non-redirect link https://github.com/OpenDroneMap/ODM/blob/master/code_of_conduct.md to get to this point, which 63 words in, conveys what exactly? Most of it is redundant to law even, a quandry in itself. The elevation of righteousness, even as it describes positions, may not be there entirely by accident, because it lends credibility to the next part.

The only tools on offer in the Covenant CoC is that of moving some of what are otherwise unwritten rules into ways of actually undermining meritocracy. Says I who haven't contributed a thing to this project, but small steps and big mouth ahead.

The invoked "right and responsibility" of following the code can in fact remove project maintainers.
In later versions this is "Project leaders", and in the 2.0 version it is actually "Community leaders" doing it.
While short on results, there is no shortage of bad ones.

I spare you the turmoil of sad histories and the reading of every version, but consider what we are doing when each of them have their own invariant sections. Do anyone read those for every project? I do, but then again I make a point of not contributing to them, so here we are without clothes. The catch-22 is getting fewer contributions, from people that can't put their effort-foot forwards without stepping in it. (I'll take the pun at this point.)

If we in the hypothetical realm are to read the CoC, in practice is that of lending a credence of what the CoC _ought_ to do, in signalling _something_, that is perhaps even more far-fetched than its original premise.

The idea is in effect that someone anti-social enough to engage in any of these stated behaviours, would somehow find it that disobeying a text-file is what keeps them from doing what are vastly more egregious offences. We are even at a stretch there, because getting as wishful in our thinking, means we have (and presumptedly do) read the text. Is that really the case? Are we looking at the text when we think about what the text does any more than someone likely to break it in the first place? If it is somewhere in between, then great, get murder on the books quick. Because who wants that?

It is this ought-smuggling that really doesn't translate. If we are to interpret between the lines, what chances does anyone else have of _getting it_? Is the preaching to the choir not inaudible? I take it a more likely scenario is that of creating false security for the kind of people that really could do without.

Now we could get into an argument about what professionalism, jokes, and sexuality means for humans, and while I find the text lacking in clarity beyond "reasonable", (which is to say at all) it gets predictably worse for later versions, as an extension to that argument.

@smathermather  I was puzzled to find you championing a CoC, and the adaption of this one in particular.
"Free speech" is not what its effects are, as not allowing "trolling", or as you will have to grant "sexual language", isn't even vague at best. The 2.0 version has "political attacks" added too.
The person writing it at GitHub in charge of inclusion, was fired from GitHub for not practising inclusion. In a further irony, you championed FOSS, and the person has gone on to make a license that isn't even libre.
I mention this because it is said to be a political tool by its creator, a person that also tries to dismantle meritocracy in yet other efforts. To each their own, but it struck me as fundamentally opposite to what this project states.

Now from my brief time here, this is indeed a good community, but it happens to be not the CoC I appreciate, or anything that stems from it. If I even knew about it, the tree could have fallen or not.
Weblate used to have the unchanged 1.4 version, and then it was replaced with the proposal, without issue. Much like before it was introduced actually. It is a great community in all capacities. In Remmina I made a point to do so, and the donations went up sharply. As an aside, the anti-community Crowdin does have a CoC, joining the likes of the mafia and the catholic church in so doing. We need an example of a project where it has done anything to complete the set, and I'm listening.

In defence of the CoC, the only part I find charitable is to attach a name and a face to a means of contact in the escalation of conflict. Enforcing this in secret is a disaster, but this version is rather curious endeavour without that part. Neither a hidden decision system nor the mere concept of having a means of contact is a way to codify behaviour. As such the only good point of the CoC does not a CoC make. To deduct a further point from the functionality of the Covenant CoC, it is no longer at the expected end in the 2.0 version, but I digress. It is maintained in the _keep in snimple snupple_ proposal, and evident from its title. It would be better to have the alternative for a private means of contact IMO.

TL;DR Will you read the 36 words of the proposal, or do you implicitly grant even that is too much to ask? :)