### PR TITLE
Try to estimate GSD for flipped Z axis datasets

### DIFF
--- a/opendm/gsd.py
+++ b/opendm/gsd.py
@@ -127,9 +127,7 @@ def opensfm_reconstruction_average_gsd(reconstruction_json, use_all_shots=False)
                                                         camera['width']))
     
     if len(gsds) > 0:
-        mean = np.mean(gsds)
-        if mean > 0:
-            return mean
+        return abs(np.mean(gsds))
     
     return None
 

--- a/opendm/gsd.py
+++ b/opendm/gsd.py
@@ -127,7 +127,10 @@ def opensfm_reconstruction_average_gsd(reconstruction_json, use_all_shots=False)
                                                         camera['width']))
     
     if len(gsds) > 0:
-        return abs(np.mean(gsds))
+        mean = np.mean(gsds)
+        if mean < 0:
+            log.ODM_WARNING("Negative GSD estimated, this might indicate a flipped Z-axis.")
+        return abs(mean)
     
     return None
 


### PR DESCRIPTION
Sometimes a dataset will be reconstructed upside down. The program in this case should still try to come up with a GSD estimate to avoid slowdowns in later stages of the pipeline.