### PR TITLE
Ensure GFlags is compiled with -fPIC

### DIFF
--- a/SuperBuild/cmake/External-GFlags.cmake
+++ b/SuperBuild/cmake/External-GFlags.cmake
@@ -14,6 +14,7 @@ ExternalProject_Add(${_proj_name}
   #--Configure step-------------
   SOURCE_DIR        ${SB_SOURCE_DIR}/${_proj_name}
   CMAKE_ARGS
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     -DCMAKE_BUILD_TYPE:STRING=Release
     -DCMAKE_INSTALL_PREFIX:PATH=${SB_INSTALL_DIR}
   #--Build step-----------------


### PR DESCRIPTION
GFlags compiled on Ubuntu 18.04 is not linkable by other projects due to
missing `-fPIC` during compilation.

* Add `-DCMAKE_POSITION_INDEPENDENT_CODE=ON` when compiling GFlags.

Signed-off-by: Daniel Llewellyn <daniel@snapcraft.ninja>