### PR TITLE
Bump OpenCV to 4.5.0 to drop libjasper requirement

### DIFF
--- a/SuperBuild/cmake/External-OpenCV.cmake
+++ b/SuperBuild/cmake/External-OpenCV.cmake
@@ -1,35 +1,13 @@
 set(_proj_name opencv)
 set(_SB_BINARY_DIR "${SB_BINARY_DIR}/${_proj_name}")
 
-ExternalProject_Add(opencv_contrib
-  PREFIX            ${_SB_BINARY_DIR}
-  TMP_DIR           ${_SB_BINARY_DIR}/tmp
-  STAMP_DIR         ${_SB_BINARY_DIR}/stamp
-  #--Download step--------------
-  DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
-  URL               https://github.com/pierotofy/opencv_contrib/archive/346sift.zip
-  #--Update/Patch step----------
-  UPDATE_COMMAND    ""
-  #--Configure step-------------
-  SOURCE_DIR        ${SB_SOURCE_DIR}/opencv_contrib
-  CONFIGURE_COMMAND ""
-  BUILD_IN_SOURCE 1
-  BUILD_COMMAND   ""
-  INSTALL_COMMAND ""
-  #--Output logging-------------
-  LOG_DOWNLOAD      OFF
-  LOG_CONFIGURE     OFF
-  LOG_BUILD         OFF
-)
-
 ExternalProject_Add(${_proj_name}
-  DEPENDS           opencv_contrib
   PREFIX            ${_SB_BINARY_DIR}
   TMP_DIR           ${_SB_BINARY_DIR}/tmp
   STAMP_DIR         ${_SB_BINARY_DIR}/stamp
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
-  URL               https://github.com/opencv/opencv/archive/3.4.6.zip
+  URL               https://github.com/opencv/opencv/archive/4.5.0.zip
   #--Update/Patch step----------
   UPDATE_COMMAND    ""
   #--Configure step-------------
@@ -68,7 +46,6 @@ ExternalProject_Add(${_proj_name}
     -DBUILD_opencv_java=OFF
     -DBUILD_opencv_ocl=OFF
     -DBUILD_opencv_ts=OFF
-    -DOPENCV_EXTRA_MODULES_PATH=${SB_SOURCE_DIR}/opencv_contrib/modules
     -DBUILD_opencv_xfeatures2d=ON
     -DCMAKE_BUILD_TYPE:STRING=Release
     -DCMAKE_INSTALL_PREFIX:PATH=${SB_INSTALL_DIR}

--- a/SuperBuild/cmake/External-OpenSfM.cmake
+++ b/SuperBuild/cmake/External-OpenSfM.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(${_proj_name}
   SOURCE_DIR        ${SB_SOURCE_DIR}/${_proj_name}
   CONFIGURE_COMMAND cmake <SOURCE_DIR>/${_proj_name}/src
     -DCERES_ROOT_DIR=${SB_INSTALL_DIR}
-    -DOpenCV_DIR=${SB_INSTALL_DIR}/share/OpenCV
+    -DOpenCV_DIR=${SB_INSTALL_DIR}/lib/cmake/opencv4
     -DOPENSFM_BUILD_TESTS=off
     -DPYTHON_EXECUTABLE=/usr/bin/python3
   #--Build step-----------------

--- a/configure.sh
+++ b/configure.sh
@@ -81,11 +81,6 @@ install() {
                          liblapack-dev \
                          libeigen3-dev \
                          libvtk6-dev
-						 
-	sudo add-apt-repository "deb http://security.ubuntu.com/ubuntu xenial-security main"
-    sudo apt-get update
-	sudo apt-get install -y -qq  --no-install-recommends libjasper1 \
-                         libjasper-dev
 	
     echo "Installing OpenSfM Dependencies"
     sudo apt-get install -y -qq  --no-install-recommends libgoogle-glog-dev \


### PR DESCRIPTION
OpenCV 3.4.6 requires libjasper which is not supported on Ubuntu 18.04+

* Update OpenCV download URL to version 4.5.0
* Drop opencv_contrib target and external project (the Sift algorithm is
  now in OpenCV upstream so we don't need the contrib anymore)
* Update OpenSfM build definition to reference new location for OpenCV
  compiled binaries

--

PLEASE test this thoroughly!

Signed-off-by: Daniel Llewellyn <daniel@snapcraft.ninja>