### PR TITLE
Update GCC Wrapper scripts for portable build

### DIFF
--- a/docker/g++
+++ b/docker/g++
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-args=""
+declare -a args
 
 for i in "$@"
 do
-    if [[ $i != -march* ]]; then
-        args="$args $i"
+    if [[ "$i" != -march* ]]; then
+        args+=("$i")
     fi
 done
 
-/usr/bin/g++_real -march=nehalem $args
+/usr/bin/g++_real -march=nehalem "${args[@]}"

--- a/docker/gcc
+++ b/docker/gcc
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-args=""
+declare -a args
 
 for i in "$@"
 do
-    if [[ $i != -march* ]]; then
-        args="$args $i"
+    if [[ "$i" != -march* ]]; then
+        args+=("$i")
     fi
 done
 
-/usr/bin/gcc_real -march=nehalem $args
+/usr/bin/gcc_real -march=nehalem "${args[@]}"


### PR DESCRIPTION
The wrapper scripts incorrectly unwrapped arguments with spaces making
them appear to be multiple individual arguments instead of one quoted
argument.

ref: https://github.com/OpenDroneMap/ODM/pull/1170#issuecomment-716607868

Signed-off-by: Daniel Llewellyn <daniel@snapcraft.ninja>