### PR TITLE
Working Snap based on core18 (Ubuntu 18.04 base)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ opencv.zip
 settings.yaml
 .setupdevenv
 __pycache__
+*.snap

--- a/SuperBuild/cmake/External-OpenCV.cmake
+++ b/SuperBuild/cmake/External-OpenCV.cmake
@@ -1,35 +1,13 @@
 set(_proj_name opencv)
 set(_SB_BINARY_DIR "${SB_BINARY_DIR}/${_proj_name}")
 
-ExternalProject_Add(opencv_contrib
-  PREFIX            ${_SB_BINARY_DIR}
-  TMP_DIR           ${_SB_BINARY_DIR}/tmp
-  STAMP_DIR         ${_SB_BINARY_DIR}/stamp
-  #--Download step--------------
-  DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
-  URL               https://github.com/pierotofy/opencv_contrib/archive/346sift.zip
-  #--Update/Patch step----------
-  UPDATE_COMMAND    ""
-  #--Configure step-------------
-  SOURCE_DIR        ${SB_SOURCE_DIR}/opencv_contrib
-  CONFIGURE_COMMAND ""
-  BUILD_IN_SOURCE 1
-  BUILD_COMMAND   ""
-  INSTALL_COMMAND ""
-  #--Output logging-------------
-  LOG_DOWNLOAD      OFF
-  LOG_CONFIGURE     OFF
-  LOG_BUILD         OFF
-)
-
 ExternalProject_Add(${_proj_name}
-  DEPENDS           opencv_contrib
   PREFIX            ${_SB_BINARY_DIR}
   TMP_DIR           ${_SB_BINARY_DIR}/tmp
   STAMP_DIR         ${_SB_BINARY_DIR}/stamp
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
-  URL               https://github.com/opencv/opencv/archive/3.4.6.zip
+  URL               https://github.com/opencv/opencv/archive/4.5.0.zip
   #--Update/Patch step----------
   UPDATE_COMMAND    ""
   #--Configure step-------------
@@ -68,7 +46,6 @@ ExternalProject_Add(${_proj_name}
     -DBUILD_opencv_java=OFF
     -DBUILD_opencv_ocl=OFF
     -DBUILD_opencv_ts=OFF
-    -DOPENCV_EXTRA_MODULES_PATH=${SB_SOURCE_DIR}/opencv_contrib/modules
     -DBUILD_opencv_xfeatures2d=ON
     -DCMAKE_BUILD_TYPE:STRING=Release
     -DCMAKE_INSTALL_PREFIX:PATH=${SB_INSTALL_DIR}

--- a/SuperBuild/cmake/External-OpenSfM.cmake
+++ b/SuperBuild/cmake/External-OpenSfM.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(${_proj_name}
   SOURCE_DIR        ${SB_SOURCE_DIR}/${_proj_name}
   CONFIGURE_COMMAND cmake <SOURCE_DIR>/${_proj_name}/src
     -DCERES_ROOT_DIR=${SB_INSTALL_DIR}
-    -DOpenCV_DIR=${SB_INSTALL_DIR}/share/OpenCV
+    -DOpenCV_DIR=${SB_INSTALL_DIR}/lib/cmake/opencv4
     -DOPENSFM_BUILD_TESTS=off
     -DPYTHON_EXECUTABLE=/usr/bin/python3
   #--Build step-----------------

--- a/SuperBuild/cmake/External-OpenSfM.cmake
+++ b/SuperBuild/cmake/External-OpenSfM.cmake
@@ -12,6 +12,7 @@ ExternalProject_Add(${_proj_name}
   GIT_TAG           200
   #--Update/Patch step----------
   UPDATE_COMMAND    git submodule update --init --recursive
+  PATCH_COMMAND     git apply ../../../patches/OpenSfM.diff
   #--Configure step-------------
   SOURCE_DIR        ${SB_SOURCE_DIR}/${_proj_name}
   CONFIGURE_COMMAND cmake <SOURCE_DIR>/${_proj_name}/src

--- a/configure.sh
+++ b/configure.sh
@@ -81,11 +81,6 @@ install() {
                          liblapack-dev \
                          libeigen3-dev \
                          libvtk6-dev
-						 
-	sudo add-apt-repository "deb http://security.ubuntu.com/ubuntu xenial-security main"
-    sudo apt-get update
-	sudo apt-get install -y -qq  --no-install-recommends libjasper1 \
-                         libjasper-dev
 	
     echo "Installing OpenSfM Dependencies"
     sudo apt-get install -y -qq  --no-install-recommends libgoogle-glog-dev \

--- a/patches/OpenSfM.diff
+++ b/patches/OpenSfM.diff
@@ -1,0 +1,47 @@
+diff --git a/opensfm/context.py b/opensfm/context.py
+index a01dd700..f54fcf87 100644
+--- a/opensfm/context.py
++++ b/opensfm/context.py
+@@ -17,6 +17,9 @@ BOW_PATH = os.path.join(abspath, 'data', 'bow')
+ 
+ 
+ # Handle different OpenCV versions
++OPENCV5 = int(cv2.__version__.split('.')[0]) >= 5 #future proofing SIFT support test (see features.py)
++OPENCV4 = int(cv2.__version__.split('.')[0]) >= 4
++OPENCV44 = int(cv2.__version__.split('.')[0]) == 4 and int(cv2.__version__.split('.')[1]) >= 4 # for SIFT support (see features.py)
+ OPENCV3 = int(cv2.__version__.split('.')[0]) >= 3
+ 
+ if hasattr(cv2, 'flann_Index'):
+diff --git a/opensfm/features.py b/opensfm/features.py
+index 3e80224b..78e51ce5 100644
+--- a/opensfm/features.py
++++ b/opensfm/features.py
+@@ -87,7 +87,13 @@ def _in_mask(point, width, height, mask):
+ def extract_features_sift(image, config):
+     sift_edge_threshold = config['sift_edge_threshold']
+     sift_peak_threshold = float(config['sift_peak_threshold'])
+-    if context.OPENCV3:
++    # SIFT support is in cv2 main from version 4.4.0
++    if context.OPENCV44 or context.OPENCV5:
++        detector = cv2.SIFT_create(
++            edgeThreshold=sift_edge_threshold,
++            contrastThreshold=sift_peak_threshold)
++        descriptor = detector
++    elif context.OPENCV3:
+         try:
+             detector = cv2.xfeatures2d.SIFT_create(
+                 edgeThreshold=sift_edge_threshold,
+@@ -105,7 +110,12 @@ def extract_features_sift(image, config):
+     while True:
+         logger.debug('Computing sift with threshold {0}'.format(sift_peak_threshold))
+         t = time.time()
+-        if context.OPENCV3:
++        # SIFT support is in cv2 main from version 4.4.0
++        if context.OPENCV44 or context.OPENCV5:
++            detector = cv2.SIFT_create(
++                edgeThreshold=sift_edge_threshold,
++                contrastThreshold=sift_peak_threshold)
++        elif context.OPENCV3:
+             detector = cv2.xfeatures2d.SIFT_create(
+                 edgeThreshold=sift_edge_threshold,
+                 contrastThreshold=sift_peak_threshold)

--- a/snap/local/usr/lib/python3.6/sitecustomize.py
+++ b/snap/local/usr/lib/python3.6/sitecustomize.py
@@ -1,0 +1,22 @@
+import site
+import os
+
+snap_dir = os.getenv("SNAP")
+snapcraft_stage_dir = os.getenv("SNAPCRAFT_STAGE")
+snapcraft_part_install = os.getenv("SNAPCRAFT_PART_INSTALL")
+
+# Do not include snap_dir during builds as this will include
+# snapcraft's in-snap site directory.
+if snapcraft_stage_dir is not None and snapcraft_part_install is not None:
+    site_directories = [snapcraft_stage_dir, snapcraft_part_install]
+else:
+    superbuild_dir = os.path.join(snap_dir, 'odm/SuperBuild/install')
+    site_directories = [snap_dir, superbuild_dir]
+
+for d in site_directories:
+    if d:
+        site_dir = os.path.join(d, "lib/python3.6/site-packages")
+        site.addsitedir(site_dir)
+
+if snap_dir:
+    site.ENABLE_USER_SITE = False

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,262 @@
+name: opendronemap
+adopt-info: odm
+grade: devel
+confinement: strict
+base: core18
+
+summary: Command line toolkit for processing aerial drone imagery
+description: >
+  An open source command line toolkit for processing aerial drone imagery. ODM turns simple 2D images into:
+
+  * Classified Point Clouds
+  * 3D Textured Models
+  * Georeferenced Orthorectified Imagery
+  * Georeferenced Digital Elevation Models
+
+  The application is available for Windows, Mac and Linux and it works from the command line, making it ideal for power users, scripts and for integration with other software.
+
+# The UbuntuGIS PPA only has i386 and amd64 packages so we can't build any
+# other architectures. Therefore let's limit to those here.
+architectures:
+  - build-on: i386
+    run-on: i386
+  - build-on: amd64
+    run-on: amd64
+
+# Requires snapcraft to be called with --enable-experimental-package-repositories
+# until the feature is released
+package-repositories:
+  - type: apt
+    ppa: ubuntugis/ubuntugis-unstable
+
+parts:
+  odm:
+    source: .
+    plugin: nil # We will script everything ourselves
+    build-environment:
+      # Set Python location to build host's system so that we can
+      # use system libraries while building the Snap Package
+      - PYTHONHOME: /usr
+      # Set the location for pip to install requirements into inside
+      # the Snap package
+      - PYTHONUSERBASE: $SNAPCRAFT_PART_INSTALL
+    override-build: |
+      snapcraftctl set-version $(cat VERSION)
+
+      pip3 install --user -r requirements.txt
+
+      # Build the SuperBuild libraries
+      mkdir -p SuperBuild/build
+      cd SuperBuild/build
+      cmake -G Ninja ..
+      cmake --build .  --parallel 1
+
+      # Build the main ODM project
+      cd $SNAPCRAFT_PART_BUILD
+      mkdir -p build
+      cd build
+      cmake -G Ninja ..
+      cmake --build . --parallel $SNAPCRAFT_PARALLEL_BUILD_COUNT
+
+      rsync -av --exclude .git \
+        $SNAPCRAFT_PART_BUILD/ $SNAPCRAFT_PART_INSTALL/odm/
+      chmod -R u=rwX,go=rX $PYTHONUSERBASE/lib/python*
+    stage:
+      # include the libraries and execuables from debian packages
+      - bin
+      - lib
+      - share
+      - usr/bin
+      - usr/lib
+      - usr/share
+
+      # remove deb-based numpy because it conflicts with our pip-installed version
+      - -usr/lib/python3/dist-packages/numpy
+
+      # include the odm directory ...
+      - odm
+      # ... but strip the temporary build files and sources
+      - -odm/SuperBuild/build/opencv
+      - -odm/SuperBuild/download
+      - -odm/SuperBuild/src/ceres
+      - -odm/SuperBuild/src/entwine
+      - -odm/SuperBuild/src/gflags
+      - -odm/SuperBuild/src/hexer
+      - -odm/SuperBuild/src/lastools
+      - -odm/SuperBuild/src/laszip
+      - -odm/SuperBuild/src/mvstexturing
+      - -odm/SuperBuild/src/opencv
+      - -odm/SuperBuild/src/opengv
+      - -odm/SuperBuild/src/pcl
+      - -odm/SuperBuild/src/pdal
+      - -odm/SuperBuild/src/zstd
+    prime:
+      # remove any static-libraries
+      - -**/*.a
+      # remove any header files
+      - -**/*.h
+      # remove any left-over temporary compiled 'object' files
+      - -**/*.o
+    build-snaps:
+      - cmake
+    build-packages:
+      - build-essential
+      - gdal-bin
+      - git
+      - grass-core
+      - libboost-log-dev
+      - libgdal-dev
+      - libgeotiff-dev
+      - libjsoncpp-dev
+      - libssl-dev
+      - libusb-dev
+      - ninja-build
+      - python3-gdal
+      - python3-pip
+      - python3-setuptools
+      - python3-wheel
+      - rsync
+      - swig3.0
+      # OpenCV
+      - libavcodec-dev
+      - libavformat-dev
+      - libeigen3-dev
+      - libflann-dev
+      - libgtk2.0-dev
+      - libjpeg-dev
+      - liblapack-dev
+      - libpng-dev
+      - libproj-dev
+      - libswscale-dev
+      - libtbb-dev
+      - libtbb2
+      - libtiff-dev
+      - libvtk6-dev
+      - libxext-dev
+      - python3-dev
+      # OpenSfM
+      - libboost-date-time-dev
+      - libboost-filesystem-dev
+      - libboost-iostreams-dev
+      - libboost-python-dev
+      - libboost-regex-dev
+      - libboost-thread-dev
+      - libgoogle-glog-dev
+      - libsuitesparse-dev
+    stage-packages:
+      - gdal-bin
+      - grass-core
+      - libaec0
+      - libamd2
+      - libasn1-8-heimdal
+      - libavcodec57
+      - libavformat57
+      - libboost-filesystem1.65.1
+      - libboost-iostreams1.65.1
+      - libboost-system1.65.1
+      - libboost-thread1.65.1
+      - libcamd2
+      - libccolamd2
+      - libcfitsio5
+      - libcharls1
+      - libcholmod3
+      - libcolamd2
+      - libcurl3-gnutls
+      - libcxsparse3
+      - libdap25
+      - libdapclient6v5
+      - libepsilon1
+      - libflann1.9
+      - libfontconfig1
+      - libfreetype6
+      - libfreexl1
+      - libfyba0
+      - libgdal26
+      - libgeos-3.8.0
+      - libgeos-c1v5
+      - libgeotiff5
+      - libgflags2.2
+      - libgif7
+      - libgomp1
+      - libgoogle-glog0v5
+      - libgssapi3-heimdal
+      - libhcrypto4-heimdal
+      - libhdf4-0-alt
+      - libhdf5-100
+      - libheimbase1-heimdal
+      - libheimntlm0-heimdal
+      - libhwloc5
+      - libhx509-5-heimdal
+      - libicu60
+      - libjbig0
+      - libjpeg-turbo8
+      - libjsoncpp1
+      - libkmlbase1
+      - libkmldom1
+      - libkmlengine1
+      - libkrb5-26-heimdal
+      - liblcms2-2
+      - libldap-2.4-2
+      - libltdl7
+      - libmetis5
+      - libminizip1
+      - libmysqlclient20
+      - libnetcdf-c++4
+      - libnetcdf13
+      - libnghttp2-14
+      - libnspr4
+      - libnss3
+      - libnuma1
+      - libodbc1
+      - libogdi4.1
+      - libopenjp2-7
+      - libopenmpi2
+      - libpng16-16
+      - libpoppler73
+      - libpq5
+      - libproj19
+      - libpsl5
+      - libqhull7
+      - libroken18-heimdal
+      - librtmp1
+      - libsasl2-2
+      - libspatialite7
+      - libspqr2
+      - libsuitesparseconfig5
+      - libsz2
+      - libtbb2
+      - libtiff5
+      - libunwind8
+      - liburiparser1
+      - libvtk6.3
+      - libwebp6
+      - libwind0-heimdal
+      - libxerces-c3.2
+      - libxml2
+      - odbcinst1debian2
+      - procps
+      - python3-gdal
+      - python3-setuptools
+
+  snap-specifics:
+    source: snap/local
+    plugin: dump
+
+  snapcraft-preload:
+    source: https://github.com/sergiusens/snapcraft-preload.git
+    plugin: cmake
+    build-packages:
+      - on amd64:
+        - gcc-multilib
+        - g++-multilib
+
+apps:
+  opendronemap:
+    command: odm/run.sh
+    command-chain:
+      - bin/snapcraft-preload # Fixes multiprocessing python module
+    plugs:
+      - home
+      - network
+      - network-bind
+      - removable-media


### PR DESCRIPTION
This is a fully-working Snap package definition that can be built with `snapcraft --enable-experimental-package-repositories`. It includes the following:

* add `*.snap` to gitignore
* add temporary patch to OpenSfM to successfully build until upstream includes mapillary/OpenSfM#658 & mapillary/OpenSfM#663 (possibly merging via #1172) - Remember to revert 9320fe4 here when these changes are upstream.
* update OpenCV to 4.5.0

Currently the recipe uses a Snapcraft feature that is marked experimental, so to build the package you need to use the `--enable-experimental-package-repositories` command line argument. This status is due to be lifted in the coming release or two of Snapcraft.