### PR TITLE
Update snapcraftbuild workflow

### DIFF
--- a/.github/workflows/snapcraftbuild.yml
+++ b/.github/workflows/snapcraftbuild.yml
@@ -30,7 +30,7 @@ jobs:
         snap: ${{ steps.build.outputs.snap }}
         isClassic: 'false'
     - name: Publish unstable builds to Edge
-      if: ${{ github.ref }} == "refs/heads/master"
+      if: github.ref == "refs/heads/master"
       uses: snapcore/action-publish@v1
       with:
         store_login: ${{ secrets.STORE_LOGIN }}
@@ -38,7 +38,7 @@ jobs:
         release: edge
     - name: Publish tagged prerelease builds to Beta
       # These are identified by having a hyphen in the tag name, e.g.: v1.0.0-beta1
-      if: ${{ startsWith("refs/tags/v", github.ref) }} && ${{ contains("-", github.ref) }}
+      if: startsWith("refs/tags/v", github.ref) && contains("-", github.ref)
       uses: snapcore/action-publish@v1
       with:
         store_login: ${{ secrets.STORE_LOGIN }}
@@ -46,7 +46,7 @@ jobs:
         release: beta
     - name: Publish tagged stable or release-candidate builds to Candidate
       # These are identified by NOT having a hyphen in the tag name, OR having "-RC" or "-rc" in the tag name.
-      if: ${{ startsWith("refs/tags/v", github.ref) }} && ( ( ! ${{ contains("-", github.ref) }} ) || ${{ contains("-RC", github.ref) }} || ${{ contains("-rc", github.ref) }} )
+      if: startsWith("refs/tags/v", github.ref) && ( ( ! contains("-", github.ref) ) || contains("-RC", github.ref) || contains("-rc", github.ref) )
       uses: snapcore/action-publish@v1
       with:
         store_login: ${{ secrets.STORE_LOGIN }}

--- a/.github/workflows/snapcraftbuild.yml
+++ b/.github/workflows/snapcraftbuild.yml
@@ -4,26 +4,51 @@ on:
   push:
     branches:
     - master
+    tags:
+    - v**
 
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture:
+        - i386
+        - amd64
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build
       id: build
-      uses: snapcore/action-build@v1
+      uses: diddlesnaps/snapcraft-multiarch-action@v1
       with:
         snapcraft-args: --enable-experimental-package-repositories
+        architecture: ${{ matrix.architecture }}
     - name: Review
       uses: diddlesnaps/snapcraft-review-tools-action@v1
       with:
         snap: ${{ steps.build.outputs.snap }}
         isClassic: 'false'
-    - name: Publish playtest to Edge
+    - name: Publish unstable builds to Edge
+      if: ${{ github.ref }} == "refs/heads/master"
       uses: snapcore/action-publish@v1
       with:
         store_login: ${{ secrets.STORE_LOGIN }}
         snap: ${{ steps.build.outputs.snap }}
         release: edge
+    - name: Publish tagged prerelease builds to Beta
+      # These are identified by having a hyphen in the tag name, e.g.: v1.0.0-beta1
+      if: ${{ startsWith("refs/tags/v", github.ref) }} && ${{ contains("-", github.ref) }}
+      uses: snapcore/action-publish@v1
+      with:
+        store_login: ${{ secrets.STORE_LOGIN }}
+        snap: ${{ steps.build.outputs.snap }}
+        release: beta
+    - name: Publish tagged stable or release-candidate builds to Candidate
+      # These are identified by NOT having a hyphen in the tag name, OR having "-RC" or "-rc" in the tag name.
+      if: ${{ startsWith("refs/tags/v", github.ref) }} && ( ( ! ${{ contains("-", github.ref) }} ) || ${{ contains("-RC", github.ref) }} || ${{ contains("-rc", github.ref) }} )
+      uses: snapcore/action-publish@v1
+      with:
+        store_login: ${{ secrets.STORE_LOGIN }}
+        snap: ${{ steps.build.outputs.snap }}
+        release: candidate


### PR DESCRIPTION
* Use newly published action: `diddlesnaps/snapcraft-multiarch-action`
* Upload every push to master to the Snap Store's Edge channel
* Upload every tagged prerelease to the Snap Store's Beta channel
  (including release candidates which are also handled below)
* Upload every tagged stable or release candidate release to the Snap
  Store's Candidate Channel

(I haven't managed to test these workflows' `if:` lines on the publish steps are correct, so it might fail to parse correctly once merged in which case I'll try to fix it) EDIT: I think I've got them correct in 149baa4

Signed-off-by: Daniel Llewellyn <daniel@snapcraft.ninja>