### PR TITLE
Bump scipy dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ attrs==19.1.0
 pyodm==1.5.4
 Pillow==6.1.0
 networkx==2.2
-scipy==1.2.1
+scipy==1.5.4
 numpy==1.19.2
 pyproj==2.2.2
 Pysolar==0.6


### PR DESCRIPTION
Part of porting to Ubuntu 20.04, we need a more recent scipy:

* Update scipy to 1.5.4

Signed-off-by: Daniel Llewellyn <daniel@snapcraft.ninja>