### PR TITLE
Fix PYTHONPATH environment var in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM ubuntu:18.04 AS builder
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
-    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.6/dist-packages" \
-    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/src/opensfm" \
+    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.6/dist-packages:/code/SuperBuild/src/opensfm" \
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib"
 
 # Prepare directories
@@ -44,8 +43,7 @@ FROM ubuntu:18.04
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
-    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.6/dist-packages" \
-    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/src/opensfm" \
+    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.6/dist-packages:/code/SuperBuild/src/opensfm" \
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib"
 
 WORKDIR /code

--- a/portable.Dockerfile
+++ b/portable.Dockerfile
@@ -2,8 +2,7 @@ FROM ubuntu:18.04 AS builder
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
-    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.6/dist-packages" \
-    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/src/opensfm" \
+    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.6/dist-packages:/code/SuperBuild/src/opensfm" \
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib"
 
 # Prepare directories
@@ -44,8 +43,7 @@ FROM ubuntu:18.04
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
-    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.6/dist-packages" \
-    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/src/opensfm" \
+    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.6/dist-packages:/code/SuperBuild/src/opensfm" \
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib"
 
 WORKDIR /code


### PR DESCRIPTION
My previous evolution of the Dockerfiles grouped the `ENV` entries into
a single definition to reduce the number of intermediate Docker image
layers. Unfortunately I didn't account for the duplicate `PYTHONPATH`
definition so only the second was being applied correctly. This commit
fixes that.

* Combine multiple `ENV PYTHONPATH=` to a single definition.

Signed-off-by: Daniel Llewellyn <daniel@snapcraft.ninja>