### PR TITLE
Update builds for Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:18.04 AS builder
+FROM ubuntu:20.04 AS builder
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
-    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.6/dist-packages:/code/SuperBuild/src/opensfm" \
+    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.8/dist-packages:/code/SuperBuild/src/opensfm" \
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib"
 
 # Prepare directories
@@ -19,6 +19,11 @@ RUN rm -rf \
   /code/SuperBuild/build/opencv \
   /code/SuperBuild/download \
   /code/SuperBuild/src/ceres \
+  /code/SuperBuild/src/entwine \
+  /code/SuperBuild/src/gflags \
+  /code/SuperBuild/src/hexer \
+  /code/SuperBuild/src/lastools \
+  /code/SuperBuild/src/laszip \
   /code/SuperBuild/src/mvstexturing \
   /code/SuperBuild/src/opencv \
   /code/SuperBuild/src/opengv \
@@ -26,7 +31,8 @@ RUN rm -rf \
   /code/SuperBuild/src/pdal \
   /code/SuperBuild/src/openmvs \
   /code/SuperBuild/build/openmvs \
-  /code/SuperBuild/src/vcg
+  /code/SuperBuild/src/vcg \
+  /code/SuperBuild/src/zstd
 
 # find in /code and delete...
 RUN find /code \
@@ -39,11 +45,11 @@ RUN find /code \
 
 ### Use a second image for the final asset to reduce the number and
 # size of the layers.
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
-    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.6/dist-packages:/code/SuperBuild/src/opensfm" \
+    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.8/dist-packages:/code/SuperBuild/src/opensfm" \
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib"
 
 WORKDIR /code

--- a/configure.sh
+++ b/configure.sh
@@ -5,17 +5,23 @@ APT_GET="env DEBIAN_FRONTEND=noninteractive $(command -v apt-get)"
 
 check_version(){
   UBUNTU_VERSION=$(lsb_release -r)
-  if [[ $UBUNTU_VERSION = *"18.04"* ]]; then
-    echo "Ubuntu: $UBUNTU_VERSION, good!"
-  elif [[ $UBUNTU_VERSION = *"16.04" ]]; then
-    echo "ODM 2.0 has upgraded to Ubuntu 18.04, but you're on 16.04"
-    echo "The last version of ODM that supports Ubuntu 16.04 is v1.0.2. We recommend you upgrade to Ubuntu 18.04, or better yet, use docker."
-    exit 1
-  else
-    echo "You are not on Ubuntu 18.04 (detected: $UBUNTU_VERSION)"
-    echo "It might be possible to run ODM on a newer version of Ubuntu, however, you cannot rely on this script."
-    exit 1
-  fi
+  case "$UBUNTU_VERSION" in
+    *"20.04"*)
+      echo "Ubuntu: $UBUNTU_VERSION, good!"
+      ;;
+    *"18.04"*|*"16.04"*)
+      echo "ODM 2.1 has upgraded to Ubuntu 20.04, but you're on $UBUNTU_VERSION"
+      echo "* The last version of ODM that supports Ubuntu 16.04 is v1.0.2."
+      echo "* The last version of ODM that supports Ubuntu 18.04 is v2.0.0."
+      echo "We recommend you upgrade to Ubuntu 18.04, or better yet, use docker."
+      exit 1
+      ;;
+    *)
+      echo "You are not on Ubuntu 20.04 (detected: $UBUNTU_VERSION)"
+      echo "It might be possible to run ODM on a newer version of Ubuntu, however, you cannot rely on this script."
+      exit 1
+      ;;
+  esac
 }
 
 if [[ $2 =~ ^[0-9]+$ ]] ; then

--- a/portable.Dockerfile
+++ b/portable.Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:18.04 AS builder
+FROM ubuntu:20.04 AS builder
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
-    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.6/dist-packages:/code/SuperBuild/src/opensfm" \
+    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.8/dist-packages:/code/SuperBuild/src/opensfm" \
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib"
 
 # Prepare directories
@@ -19,6 +19,11 @@ RUN rm -rf \
   /code/SuperBuild/build/opencv \
   /code/SuperBuild/download \
   /code/SuperBuild/src/ceres \
+  /code/SuperBuild/src/entwine \
+  /code/SuperBuild/src/gflags \
+  /code/SuperBuild/src/hexer \
+  /code/SuperBuild/src/lastools \
+  /code/SuperBuild/src/laszip \
   /code/SuperBuild/src/mvstexturing \
   /code/SuperBuild/src/opencv \
   /code/SuperBuild/src/opengv \
@@ -26,7 +31,8 @@ RUN rm -rf \
   /code/SuperBuild/src/pdal \
   /code/SuperBuild/src/openmvs \
   /code/SuperBuild/build/openmvs \
-  /code/SuperBuild/src/vcg
+  /code/SuperBuild/src/vcg \
+  /code/SuperBuild/src/zstd
 
 # find in /code and delete...
 RUN find /code \
@@ -39,11 +45,11 @@ RUN find /code \
 
 ### Use a second image for the final asset to reduce the number and
 # size of the layers.
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
-    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.6/dist-packages:/code/SuperBuild/src/opensfm" \
+    PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.8/dist-packages:/code/SuperBuild/src/opensfm" \
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib"
 
 WORKDIR /code

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@ pyodm==1.5.4
 Pillow==6.1.0
 networkx==2.2
 scipy==1.5.4
-numpy==1.19.2
-pyproj==2.2.2
+numpy==1.19.4
+pyproj==3.0.0
 Pysolar==0.6
 psutil==5.6.3
 joblib==0.17.0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -2,7 +2,7 @@ name: opendronemap
 adopt-info: odm
 grade: devel
 confinement: strict
-base: core18
+base: core20
 
 summary: Command line toolkit for processing aerial drone imagery
 description: >
@@ -38,6 +38,7 @@ parts:
       - build-essential
       - cmake
       - gdal-bin
+      - gfortran # to build scipy
       - git
       - grass-core
       - libboost-log-dev
@@ -58,7 +59,7 @@ parts:
     stage-packages:
       - gdal-bin
       - grass-core
-      - libboost-log1.65.1
+      - libboost-log1.71.0
       - libgdal26
       - libgeotiff5
       - libjsoncpp1
@@ -84,6 +85,7 @@ parts:
       - libgtk2.0-dev
       - libjpeg-dev
       - liblapack-dev
+      - libopenjpip7
       - libpng-dev
       - libproj-dev
       - libswscale-dev
@@ -91,16 +93,18 @@ parts:
       - libtiff-dev
       - libvtk6-dev
       - libxext-dev
+      - proj-bin
     stage-packages:
-      - libavcodec57
-      - libavformat57
+      - libavcodec58
+      - libavformat58
       - libflann1.9
       - libgtk2.0-0
       - libjpeg-turbo8
+      - libopenjpip7
       - liblapack3
       - libpng16-16
       - libproj19
-      - libswscale4
+      - libswscale5
       - libtbb2
       - libtiff5
       - libvtk6.3
@@ -114,8 +118,7 @@ parts:
       - libcgal-dev
       - libboost-program-options-dev
     stage-packages:
-      - libboost-program-options1.65.1
-      - libcgal-dev
+      - libboost-program-options1.71.0
 
   opensfm:
     source: .
@@ -127,18 +130,21 @@ parts:
       - libboost-iostreams-dev
       - libboost-python-dev
       - libboost-regex-dev
+      - libboost-serialization-dev
+      - libboost-system-dev
       - libboost-thread-dev
       - libgoogle-glog-dev
       - libsuitesparse-dev
     stage-packages:
       - libamd2
-      - libboost-date-time1.65.1
-      - libboost-filesystem1.65.1
-      - libboost-iostreams1.65.1
-      - libboost-python1.65.1
-      - libboost-regex1.65.1
-      - libboost-system1.65.1
-      - libboost-thread1.65.1
+      - libboost-date-time1.71.0
+      - libboost-filesystem1.71.0
+      - libboost-iostreams1.71.0
+      - libboost-python1.71.0
+      - libboost-regex1.71.0
+      - libboost-serialization1.71.0
+      - libboost-system1.71.0
+      - libboost-thread1.71.0
       - libcamd2
       - libccolamd2
       - libcholmod3
@@ -186,6 +192,7 @@ parts:
     stage:
       # strip the temporary build files and sources
       - -odm/SuperBuild/build/opencv
+      - -odm/SuperBuild/build/openmvs
       - -odm/SuperBuild/download
       - -odm/SuperBuild/src/ceres
       - -odm/SuperBuild/src/entwine
@@ -195,9 +202,11 @@ parts:
       - -odm/SuperBuild/src/laszip
       - -odm/SuperBuild/src/mvstexturing
       - -odm/SuperBuild/src/opencv
+      - -odm/SuperBuild/src/opengv
       - -odm/SuperBuild/src/openmvs
       - -odm/SuperBuild/src/pcl
       - -odm/SuperBuild/src/pdal
+      - -odm/SuperBuild/src/vcg
       - -odm/SuperBuild/src/zstd
     prime:
       # remove any static-libraries


### PR DESCRIPTION
* Adjust `PYTHONPATH` in Dockerfiles to newer `python3.8`
* Switch to 20.04 base images in Dockerfiles
* Switch snapcraft to use `base20`
* Update APT dependency versions in `snapcraft.yaml` to match those
  available in Ubuntu 20.04
* Bump `pyproj` from version `2.2.2` to `3.0.0`
* Bump `numpy` from version `1.19.2` to `1.19.4`
* Add missing exclusions to `snapcraft.yaml` to reduce the size of snap
  packages
* Add missing exclusions to Dockerfiles to reduce the size of container
  images
* Update `configure.sh` to account for Ubuntu 20.04 instead of 18.04
* Nit: make `configure.sh` executable directly with `./configure.sh`
  instead of `bash configure.sh`

Signed-off-by: Daniel Llewellyn <daniel@snapcraft.ninja>