### PR TITLE
Mark Snap as grade: stable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: opendronemap
 adopt-info: odm
-grade: devel
+grade: stable
 confinement: strict
 base: core18
 


### PR DESCRIPTION
Snap packages marked as `grade: devel` are not permitted to be released
to the `candidate` or `stable` channels in the Snap Store. This commit
changes the grade to `stable` now that everything seems to be working
well. Snaps build from this commit forward will be releasable to the
`candidate` and/or `stable` channels in the Snap Store :-)

Signed-off-by: Daniel Llewellyn <daniel@snapcraft.ninja>