### PR TITLE
Update snapcraft.yaml for core20/snapcraft-preload

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -234,7 +234,7 @@ apps:
   opendronemap:
     command: odm/run.sh
     command-chain:
-      - bin/snapcraft-preload # Fixes multiprocessing python module
+      - usr/local/bin/snapcraft-preload # Fixes multiprocessing python module
     plugs:
       - home
       - network


### PR DESCRIPTION
It seems that snapcraft-preload[1] installs to a different location when
building with core20 vs core18. This meant the snap builds fail with
being unable to find the executable. This commit changes the reference
to the preload script in the `snapcraft.yaml` to the core20-built
location.

[1] https://github.com/sergiusens/snapcraft-preload

Signed-off-by: Daniel Llewellyn <daniel@snapcraft.ninja>