### PR TITLE
Update snapcraft.yaml for missing webp library

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -108,6 +108,7 @@ parts:
       - libtbb2
       - libtiff5
       - libvtk6.3
+      - libwebpdemux2
       - libxext6
   
   openmvs:


### PR DESCRIPTION
Snapcraft complains about missing `libwebpdemux2` when building. This
commit adds it as a runtime dependency to fix the warning.

Signed-off-by: Daniel Llewellyn <daniel@snapcraft.ninja>