### PR TITLE
Update to add some missing python packages in Snap

### DIFF
--- a/snap/local/usr/lib/python3.8/sitecustomize.py
+++ b/snap/local/usr/lib/python3.8/sitecustomize.py
@@ -15,7 +15,7 @@ else:
 
 for d in site_directories:
     if d:
-        site_dir = os.path.join(d, "lib/python3.6/site-packages")
+        site_dir = os.path.join(d, "lib/python3.8/site-packages")
         site.addsitedir(site_dir)
 
 if snap_dir:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,7 +33,6 @@ parts:
   prereqs:
     source: .
     plugin: nil
-    override-pull: exit 0
     build-packages:
       - build-essential
       - cmake
@@ -67,7 +66,11 @@ parts:
       - libssl1.1
       - libusb-1.0-0
       - procps
+      - python3
+      - python3-distutils
       - python3-gdal
+      - python3-pkg-resources # required base package for core20
+      - python3-requests # required base package for core20
       - python3-setuptools
     stage:
       # remove deb-based numpy because it conflicts with our pip-installed version
@@ -76,7 +79,6 @@ parts:
   opencv:
     source: .
     plugin: nil
-    override-pull: exit 0
     build-packages:
       - libavcodec-dev
       - libavformat-dev
@@ -114,7 +116,6 @@ parts:
   openmvs:
     source: .
     plugin: nil
-    override-pull: exit 0
     build-packages:
       - libcgal-dev
       - libboost-program-options-dev
@@ -124,7 +125,6 @@ parts:
   opensfm:
     source: .
     plugin: nil
-    override-pull: exit 0
     build-packages:
       - libboost-date-time-dev
       - libboost-filesystem-dev
@@ -226,6 +226,8 @@ parts:
   snapcraft-preload:
     source: https://github.com/sergiusens/snapcraft-preload.git
     plugin: cmake
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/
     build-packages:
       - on amd64:
         - gcc-multilib
@@ -235,7 +237,10 @@ apps:
   opendronemap:
     command: odm/run.sh
     command-chain:
-      - usr/local/bin/snapcraft-preload # Fixes multiprocessing python module
+      - bin/snapcraft-preload # Fixes multiprocessing python module
+    environment:
+      # Ensure libraries are found
+      LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lapack:$LD_LIBRARY_PATH
     plugs:
       - home
       - network


### PR DESCRIPTION
I think this was caused by the release of Snapcraft 4.4 recently which
might have different behaviour. The snap is missing a few python
packages/modules now, which were present when building earlier.

* Add missing Python packages
* Ensure libblas and liblapack can be found with an LD_LIBRARY_PATH
  override.
* Rename reference to `python3.6` to `python3.8`.

Ref: https://community.opendronemap.org/t/issue-with-snap/5924

Signed-off-by: Daniel Llewellyn <daniel@snapcraft.ninja>