### PR TITLE
Disable attempts to build Snap for i386

### DIFF
--- a/.github/workflows/snapcraftbuild.yml
+++ b/.github/workflows/snapcraftbuild.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         architecture:
-        - i386
         - amd64
     steps:
     - name: Checkout

--- a/.github/workflows/test-build-prs.yaml
+++ b/.github/workflows/test-build-prs.yaml
@@ -25,7 +25,6 @@ jobs:
     strategy:
       matrix:
         architecture:
-        - i386
         - amd64
     steps:
     - name: Checkout


### PR DESCRIPTION
Ubuntu 20.04 Does not support i386, so attempting to build the Snap for
i386 will either fail or be non-runnable on an i386 Linux distro.

* Disable i386 build in `snapcraftbuild.yml` GitHub Action workflow
* Disable i386 build when testing PRs for consistency

Signed-off-by: Daniel Llewellyn <daniel@snapcraft.ninja>