### PR TITLE
Double, Original, Half, Quarter, and Eighth for pc-quality & feature-quality

### DIFF
--- a/opendm/config.py
+++ b/opendm/config.py
@@ -152,7 +152,7 @@ def config(argv=None, parser=None):
                         metavar='<string>',
                         action=StoreValue,
                         default='high',
-                        choices=['ultra', 'super', 'hyper', 'high', 'medium', 'low'],
+                        choices=['double', 'original', 'half', 'quarter', 'eighth'],
                         help=('Set feature extraction quality. Higher quality generates better features, but requires more memory and takes longer. '
                             'Can be one of: %(choices)s. Default: '
                             '%(default)s'))
@@ -361,7 +361,7 @@ def config(argv=None, parser=None):
                     metavar='<string>',
                     action=StoreValue,
                     default='medium',
-                    choices=['ultra', 'super', 'hyper', 'high', 'medium', 'low'],
+                    choices=['double', 'original', 'half', 'quarter', 'eighth'],
                     help=('Set point cloud quality. Higher quality generates better, denser point clouds, but requires more memory and takes longer. Each step up in quality increases processing time roughly by a factor of 4x.'
                         'Can be one of: %(choices)s. Default: '
                         '%(default)s'))

--- a/opendm/config.py
+++ b/opendm/config.py
@@ -152,7 +152,7 @@ def config(argv=None, parser=None):
                         metavar='<string>',
                         action=StoreValue,
                         default='high',
-                        choices=['ultra', 'super', 'hyper', 'high', 'medium', 'low', 'lowest'],
+                        choices=['ultra', 'super', 'hyper', 'high', 'medium', 'low'],
                         help=('Set feature extraction quality. Higher quality generates better features, but requires more memory and takes longer. '
                             'Can be one of: %(choices)s. Default: '
                             '%(default)s'))

--- a/opendm/config.py
+++ b/opendm/config.py
@@ -152,7 +152,7 @@ def config(argv=None, parser=None):
                         metavar='<string>',
                         action=StoreValue,
                         default='high',
-                        choices=['ultra', 'high', 'medium', 'low', 'lowest'],
+                        choices=['ultra', 'super', 'hyper', 'high', 'medium', 'low', 'lowest'],
                         help=('Set feature extraction quality. Higher quality generates better features, but requires more memory and takes longer. '
                             'Can be one of: %(choices)s. Default: '
                             '%(default)s'))
@@ -361,7 +361,7 @@ def config(argv=None, parser=None):
                     metavar='<string>',
                     action=StoreValue,
                     default='medium',
-                    choices=['ultra', 'high', 'medium', 'low'],
+                    choices=['ultra', 'super', 'hyper', 'high', 'medium', 'low'],
                     help=('Set point cloud quality. Higher quality generates better, denser point clouds, but requires more memory and takes longer. Each step up in quality increases processing time roughly by a factor of 4x.'
                         'Can be one of: %(choices)s. Default: '
                         '%(default)s'))

--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -154,11 +154,12 @@ class OSFMContext:
                 feature_process_size = int(args.resize_to)
             else:
                 feature_quality_scale = {
-                    'ultra': 1,
-                    'high': 0.5,
-                    'medium': 0.25,
-                    'low': 0.125,
-                    'lowest': 0.0675,
+                    'ultra': 1.00,
+                    'super': 0.75,
+                    'hyper': 0.50,
+                    'high': 0.25,
+                    'medium': 0.125,
+                    'low': 0.0675,
                 }
 
                 max_dim = find_largest_photo_dim(photos)

--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -154,12 +154,11 @@ class OSFMContext:
                 feature_process_size = int(args.resize_to)
             else:
                 feature_quality_scale = {
-                    'ultra': 1.00,
-                    'super': 0.75,
-                    'hyper': 0.50,
-                    'high': 0.25,
-                    'medium': 0.125,
-                    'low': 0.0675,
+                    'double': 2.00,
+                    'original': 1.00,
+                    'half': 0.50,
+                    'quarter': 0.25,
+                    'eighth': 0.125,
                 }
 
                 max_dim = find_largest_photo_dim(photos)

--- a/opendm/utils.py
+++ b/opendm/utils.py
@@ -10,12 +10,11 @@ def get_depthmap_resolution(args, photos):
         max_dim = find_largest_photo_dim(photos)
 
         pc_quality_scale = {
-            'ultra': 1.00,
-            'super': 0.75,
-            'hyper': 0.50,
-            'high': 0.25,
-            'medium': 0.125,
-            'low': 0.0675
+            'double': 2.00,
+            'original': 1.00,
+            'half': 0.50,
+            'quarter': 0.25,
+            'eighth': 0.125,
         }
 
         if max_dim > 0:

--- a/opendm/utils.py
+++ b/opendm/utils.py
@@ -10,7 +10,9 @@ def get_depthmap_resolution(args, photos):
         max_dim = find_largest_photo_dim(photos)
 
         pc_quality_scale = {
-            'ultra': 0.5,
+            'ultra': 1.00,
+            'super': 0.75,
+            'hyper': 0.50,
             'high': 0.25,
             'medium': 0.125,
             'low': 0.0675


### PR DESCRIPTION
In fighting with this particularly difficult dataset (https://community.opendronemap.org/t/error-writing-ply-file/5683/22?u=saijin_naib) I got the idea that, in some instances, it might not only be desirable, but necessary to have --pc-quality and --feature-quality values that are unmodified from the input data.

To that end, these sets of PRs basically add "super" and "hyper" quality level flags (0.75, 0.50 respectively), and bump "ultra" up to 1.00.

I also normalized the arguments that --pc-quality and --feature-quality accepted (removed "lowest", moved quality values around to match one another), to ensure that cognitively, they're the same to use and quality levels represent the same relative quality level compared to the source dataset for both flags.

I don't believe these values are unprecedented (Ultra being quality of 1.00), as I believe Pix4D Mapper allows one to use "Original" quality for a few parameters in their pipeline.