### PR TITLE
Fix phantom4 multispectral dataset

### DIFF
--- a/modules/odm_orthophoto/src/OdmOrthoPhoto.cpp
+++ b/modules/odm_orthophoto/src/OdmOrthoPhoto.cpp
@@ -493,7 +493,26 @@ void OdmOrthoPhoto::createOrthoPhoto()
             // Init ortho photo
             if (t == 0){
                 if (primary) textureDepth = texture.depth();
-                else if (textureDepth != texture.depth()) throw OdmOrthoPhotoException("Texture depth must be the same for all models");
+                else if (textureDepth != texture.depth()){
+                    // Try to convert
+                    if (textureDepth == CV_8U){
+                        if (texture.depth() == CV_16U){
+                            // 16U to 8U
+                            texture.convertTo(texture, CV_8U, 255.0f / 65535.0f);
+                        }else{
+                            throw OdmOrthoPhotoException("Unknown conversion known from CV_8U");
+                        }
+                    }else if (textureDepth == CV_16U){
+                        if (texture.depth() == CV_8U){
+                            // 8U to 16U
+                            texture.convertTo(texture, CV_16U, 65535.0f / 255.0f);
+                        }else{
+                            throw OdmOrthoPhotoException("Unknown conversion known from CV_16U");
+                        }
+                    }else{
+                         throw OdmOrthoPhotoException("Texture depth is not the same for all models and could not be converted");
+                    }
+                }
 
                 log_ << "Texture channels: " << texture.channels() << "\n";
 

--- a/modules/odm_orthophoto/src/OdmOrthoPhoto.cpp
+++ b/modules/odm_orthophoto/src/OdmOrthoPhoto.cpp
@@ -500,14 +500,14 @@ void OdmOrthoPhoto::createOrthoPhoto()
                             // 16U to 8U
                             texture.convertTo(texture, CV_8U, 255.0f / 65535.0f);
                         }else{
-                            throw OdmOrthoPhotoException("Unknown conversion known from CV_8U");
+                            throw OdmOrthoPhotoException("Unknown conversion from CV_8U");
                         }
                     }else if (textureDepth == CV_16U){
                         if (texture.depth() == CV_8U){
                             // 8U to 16U
                             texture.convertTo(texture, CV_16U, 65535.0f / 255.0f);
                         }else{
-                            throw OdmOrthoPhotoException("Unknown conversion known from CV_16U");
+                            throw OdmOrthoPhotoException("Unknown conversion from CV_16U");
                         }
                     }else{
                          throw OdmOrthoPhotoException("Texture depth is not the same for all models and could not be converted");

--- a/opendm/types.py
+++ b/opendm/types.py
@@ -40,7 +40,7 @@ class ODM_Reconstruction(object):
             if not p.band_name in band_photos:
                 band_photos[p.band_name] = []
             if not p.band_name in band_indexes:
-                band_indexes[p.band_name] = p.band_index
+                band_indexes[p.band_name] = str(p.band_index)
 
             band_photos[p.band_name].append(p)
             


### PR DESCRIPTION
Fixes necessary to process the dataset reported on https://community.opendronemap.org/t/multispectral-processing-help-please/6341/4

This allows some mixed-type bands (e.g. 8bit RGB + 16bit infrared/rededge bands) to be processed together.