### PR TITLE
Fix behaviour of PoissonRecon on ppc64le

### DIFF
--- a/SuperBuild/CMakeLists.txt
+++ b/SuperBuild/CMakeLists.txt
@@ -169,7 +169,7 @@ else()
 endif()
 externalproject_add(poissonrecon
     GIT_REPOSITORY    https://github.com/OpenDroneMap/PoissonRecon.git
-    GIT_TAG           250
+    GIT_TAG           master
     PREFIX            ${SB_BINARY_DIR}/PoissonRecon
     SOURCE_DIR        ${SB_SOURCE_DIR}/PoissonRecon
     UPDATE_COMMAND    ""

--- a/SuperBuild/CMakeLists.txt
+++ b/SuperBuild/CMakeLists.txt
@@ -198,7 +198,7 @@ externalproject_add(dem2points
 )
 
 externalproject_add(odm_orthophoto
-    DEPENDS           pcl opencv
+    DEPENDS           pcl opencv 
     GIT_REPOSITORY    https://github.com/OpenDroneMap/odm_orthophoto.git
     GIT_TAG           main
     PREFIX            ${SB_BINARY_DIR}/odm_orthophoto

--- a/SuperBuild/CMakeLists.txt
+++ b/SuperBuild/CMakeLists.txt
@@ -169,7 +169,7 @@ else()
 endif()
 externalproject_add(poissonrecon
     GIT_REPOSITORY    https://github.com/OpenDroneMap/PoissonRecon.git
-    GIT_TAG           master
+    GIT_TAG           250
     PREFIX            ${SB_BINARY_DIR}/PoissonRecon
     SOURCE_DIR        ${SB_SOURCE_DIR}/PoissonRecon
     UPDATE_COMMAND    ""
@@ -198,7 +198,7 @@ externalproject_add(dem2points
 )
 
 externalproject_add(odm_orthophoto
-    DEPENDS           pcl opencv 
+    DEPENDS           pcl opencv
     GIT_REPOSITORY    https://github.com/OpenDroneMap/odm_orthophoto.git
     GIT_TAG           main
     PREFIX            ${SB_BINARY_DIR}/odm_orthophoto

--- a/opendm/mesh.py
+++ b/opendm/mesh.py
@@ -145,7 +145,14 @@ def screened_poisson_reconstruction(inPointCloud, outMesh, depth = 8, samples = 
     # ext = .ply
 
     outMeshDirty = os.path.join(mesh_path, "{}.dirty{}".format(basename, ext))
-
+    
+    try:
+        # Since PoissonRecon has some kind of a race condition on ppc64el, and this helps...
+        if sys._multiarch == 'powerpc64le-linux-gnu':
+            threads = 1
+    except AttributeError:
+        pass
+    
     poissonReconArgs = {
       'bin': context.poisson_recon_path,
       'outfile': outMeshDirty,

--- a/opendm/mesh.py
+++ b/opendm/mesh.py
@@ -148,6 +148,7 @@ def screened_poisson_reconstruction(inPointCloud, outMesh, depth = 8, samples = 
     
     # Since PoissonRecon has some kind of a race condition on ppc64el, and this helps...
     if platform.machine() == 'ppc64le':
+        log.ODM_WARNING("ppc64le platform detected, forcing single-threaded operation for PoissonRecon")
         threads = 1
     
     poissonReconArgs = {

--- a/opendm/mesh.py
+++ b/opendm/mesh.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-import os, shutil, sys, struct, random, math
+import os, shutil, sys, struct, random, math, platform
 from opendm.dem import commands
 from opendm import system
 from opendm import log
@@ -146,12 +146,9 @@ def screened_poisson_reconstruction(inPointCloud, outMesh, depth = 8, samples = 
 
     outMeshDirty = os.path.join(mesh_path, "{}.dirty{}".format(basename, ext))
     
-    try:
-        # Since PoissonRecon has some kind of a race condition on ppc64el, and this helps...
-        if sys._multiarch == 'powerpc64le-linux-gnu':
-            threads = 1
-    except AttributeError:
-        pass
+    # Since PoissonRecon has some kind of a race condition on ppc64el, and this helps...
+    if platform.machine() == 'ppc64le':
+        threads = 1
     
     poissonReconArgs = {
       'bin': context.poisson_recon_path,


### PR DESCRIPTION
After long and hard fight we ([Dronehub](https://dronehub.ai)) managed to launch OpenDroneMap on ppc64le.

We will submit necessary patches over the next few weeks, but this is the first one.

PoissonRecon when compiled on ppc64le happens to have some sort of a race condition. We're evaluating it further, but it seems that keeping it to a single thread makes everything go OK.

This patch detects if we're running on ppc64le and tunes down the threads appropriately.