### PR TITLE
Fix COG compression, cap mesh-octree-depth values

### DIFF
--- a/opendm/cogeo.py
+++ b/opendm/cogeo.py
@@ -5,7 +5,7 @@ from opendm.concurrency import get_max_memory
 from opendm import io
 from opendm import log
 
-def convert_to_cogeo(src_path, blocksize=256, max_workers=1):
+def convert_to_cogeo(src_path, blocksize=256, max_workers=1, compression="DEFLATE"):
     """
     Guarantee that the .tif passed as an argument is a Cloud Optimized GeoTIFF (cogeo)
     The file is destructively converted into a cogeo.
@@ -30,6 +30,8 @@ def convert_to_cogeo(src_path, blocksize=256, max_workers=1):
         'max_memory': get_max_memory(),
         'src_path': src_path,
         'tmpfile': tmpfile,
+        'compress': compression,
+        'predictor': '2' if compression in ['LZW', 'DEFLATE'] else '1',
     }
 
     try:
@@ -37,7 +39,8 @@ def convert_to_cogeo(src_path, blocksize=256, max_workers=1):
                 "-of COG "
                 "-co NUM_THREADS={threads} "
                 "-co BLOCKSIZE={blocksize} "
-                "-co COMPRESS=deflate "
+                "-co COMPRESS={compress} "
+                "-co PREDICTOR={predictor} "
                 "-co BIGTIFF=IF_SAFER "
                 "-co RESAMPLING=NEAREST "
                 "--config GDAL_CACHEMAX {max_memory}% "

--- a/opendm/config.py
+++ b/opendm/config.py
@@ -277,7 +277,7 @@ def config(argv=None, parser=None):
                               'Default: %(default)s'))
 
     parser.add_argument('--mesh-octree-depth',
-                        metavar='<positive integer>',
+                        metavar='<integer: 1 <= x <= 14>',
                         action=StoreValue,
                         default=11,
                         type=int,

--- a/opendm/orthophoto.py
+++ b/opendm/orthophoto.py
@@ -86,7 +86,7 @@ def post_orthophoto_steps(args, bounds_file_path, orthophoto_file, orthophoto_ti
         generate_orthophoto_tiles(orthophoto_file, orthophoto_tiles_dir, args.max_concurrency)
 
     if args.cog:
-        convert_to_cogeo(orthophoto_file, max_workers=args.max_concurrency)
+        convert_to_cogeo(orthophoto_file, max_workers=args.max_concurrency, compression=args.orthophoto_compression)
 
 def compute_mask_raster(input_raster, vector_mask, output_raster, blend_distance=20, only_max_coords_feature=False):
     if not os.path.exists(input_raster):

--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -193,6 +193,7 @@ class OSFMContext:
                 "optimize_camera_parameters: %s" % ('no' if args.use_fixed_camera_params or args.cameras else 'yes'),
                 "undistorted_image_format: tif",
                 "bundle_outlier_filtering_type: AUTO",
+                "sift_peak_threshold: 0.066",
                 "align_orientation_prior: vertical",
                 "triangulation_type: ROBUST",
                 "retriangulation_ratio: 2",

--- a/stages/odm_app.py
+++ b/stages/odm_app.py
@@ -42,7 +42,7 @@ class ODMApp:
         filterpoints = ODMFilterPoints('odm_filterpoints', args, progress=52.0)
         meshing = ODMeshingStage('odm_meshing', args, progress=60.0,
                                     max_vertex=args.mesh_size,
-                                    oct_tree=args.mesh_octree_depth,
+                                    oct_tree=max(1, min(14, args.mesh_octree_depth)),
                                     samples=1.0,
                                     point_weight=4.0,
                                     max_concurrency=args.max_concurrency,

--- a/start-dev-env.sh
+++ b/start-dev-env.sh
@@ -55,7 +55,7 @@ if [ "$1" = "--setup" ]; then
 
     # Misc aliases
     echo "alias pdal=/code/SuperBuild/install/bin/pdal" >> $HOME/.bashrc
-    echo "alias opensfm=/code/SuperBuild/src/opensfm/bin/opensfm" >> $HOME/.bashrc
+    echo "alias opensfm=/code/SuperBuild/install/bin/opensfm/bin/opensfm" >> $HOME/.bashrc
     
 
     su -c bash $2


### PR DESCRIPTION
Fixes the problem reported on https://community.opendronemap.org/t/can-not-disable-cog-option-cloud-optimized-geotiffs-in-webodm/8184

Closes #1312﻿
