### PR TITLE
Fix EXIF error while using GCPs

### DIFF
--- a/stages/run_opensfm.py
+++ b/stages/run_opensfm.py
@@ -40,7 +40,7 @@ class ODMOpenSfMStage(types.ODM_Stage):
 
         def cleanup_disk_space():
             if args.optimize_disk_space:
-                for folder in ["features", "matches", "exif", "reports"]:
+                for folder in ["features", "matches", "reports"]:
                     folder_path = octx.path(folder)
                     if os.path.exists(folder_path):
                         if os.path.islink(folder_path):


### PR DESCRIPTION
When using GCPs and passing --optimize-disk-space the program will fail with: FileNotFoundError: [Errno 2] No such file or directory: ‘/var/www/data/e852b60f-abdf-47fc-a95d-d967f81b510b/opensfm/exif/DJI_0567.JPG.exif’


