### PR TITLE
Dispatch NodeODM build event, sentera 6x UUID capture tag support

### DIFF
--- a/.github/workflows/publish-docker-and-wsl.yaml
+++ b/.github/workflows/publish-docker-and-wsl.yaml
@@ -85,4 +85,8 @@ jobs:
       run: |
         echo "Docker image digest: ${{ steps.docker_build.outputs.digest }}"
         echo "WSL AMD64 rootfs URL: ${{ steps.upload-amd64-wsl-rootfs.browser_download_url }}"
-
+    # Trigger NodeODM build
+    - name: Dispatch NodeODM Build Event
+      id: nodeodm_dispatch
+      run: |
+        curl -X POST -u "${{ secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/OpenDroneMap/NodeODM/actions/workflows/publish-docker.yaml/dispatches --data '{"ref": "master"}'

--- a/.github/workflows/publish-docker-gpu.yaml
+++ b/.github/workflows/publish-docker-gpu.yaml
@@ -34,3 +34,8 @@ jobs:
         platforms: linux/amd64
         push: true
         tags: opendronemap/odm:gpu
+    # Trigger NodeODM build
+    - name: Dispatch NodeODM Build Event
+      id: nodeodm_dispatch
+      run: |
+        curl -X POST -u "${{ secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/OpenDroneMap/NodeODM/actions/workflows/publish-docker-gpu.yaml/dispatches --data '{"ref": "master"}'

--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -201,6 +201,7 @@ class ODM_Photo:
                         '@Camera:RigCameraIndex', # Parrot Sequoia, Sentera 21244-00_3.2MP-GS-0001
                         'Camera:RigCameraIndex', # MicaSense Altum
                     ])
+
                     self.set_attr_from_xmp_tag('radiometric_calibration', tags, [
                         'MicaSense:RadiometricCalibration',
                     ])
@@ -233,7 +234,8 @@ class ODM_Photo:
                     ], float)
 
                     self.set_attr_from_xmp_tag('capture_uuid', tags, [
-                        '@drone-dji:CaptureUUID'
+                        '@drone-dji:CaptureUUID', # DJI
+                        '@Camera:ImageUniqueID', # sentera 6x
                     ])
 
                     # Phantom 4 RTK


### PR DESCRIPTION
Adds support for notifying NodeODM build triggers, Sentera-6X UUID capture tag support.
﻿
