### PR TITLE
Dynamic max texture sizes

### DIFF
--- a/SuperBuild/cmake/External-MvsTexturing.cmake
+++ b/SuperBuild/cmake/External-MvsTexturing.cmake
@@ -9,7 +9,7 @@ ExternalProject_Add(${_proj_name}
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}/${_proj_name}
   GIT_REPOSITORY    https://github.com/OpenDroneMap/mvs-texturing
-  GIT_TAG           264
+  GIT_TAG           267
   #--Update/Patch step----------
   UPDATE_COMMAND    ""
   #--Configure step-------------


### PR DESCRIPTION
Creates output OBJ textures that are large only on a per-needed basis.

Fixes the issue of opening OBJs in meshlab/WebODM for most datasets (except those that have very large input images).

