### PR TITLE
Space in ODM Install Path

### DIFF
--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -31,7 +31,7 @@ class OSFMContext:
     
     def run(self, command):
         osfm_bin = os.path.join(context.opensfm_path, 'bin', 'opensfm')
-        system.run('%s %s "%s"' %
+        system.run('"%s" %s "%s"' %
                     (osfm_bin, command, self.opensfm_project_path))
 
     def is_reconstruction_done(self):

--- a/stages/openmvs.py
+++ b/stages/openmvs.py
@@ -83,7 +83,7 @@ class ODMOpenMVSStage(types.ODM_Stage):
                 config.append("--geometric-iters 0")
 
             def run_densify():
-                system.run('%s "%s" %s' % (context.omvs_densify_path, 
+                system.run('"%s" "%s" %s' % (context.omvs_densify_path, 
                                         openmvs_scene_file,
                                         ' '.join(config + gpu_config)))
 
@@ -111,7 +111,7 @@ class ODMOpenMVSStage(types.ODM_Stage):
                     '-w "%s"' % depthmaps_dir, 
                     "-v 0",
                 ]
-                system.run('%s "%s" %s' % (context.omvs_densify_path, 
+                system.run('"%s" "%s" %s' % (context.omvs_densify_path, 
                                         openmvs_scene_file,
                                         ' '.join(config + gpu_config)))
                 
@@ -145,10 +145,10 @@ class ODMOpenMVSStage(types.ODM_Stage):
                         ]
 
                         try:
-                            system.run('%s "%s" %s' % (context.omvs_densify_path, sf, ' '.join(config + gpu_config)))
+                            system.run('"%s" "%s" %s' % (context.omvs_densify_path, sf, ' '.join(config + gpu_config)))
 
                             # Filter
-                            system.run('%s "%s" --filter-point-cloud -1 -v 0 %s' % (context.omvs_densify_path, scene_dense_mvs, ' '.join(gpu_config)))
+                            system.run('"%s" "%s" --filter-point-cloud -1 -v 0 %s' % (context.omvs_densify_path, scene_dense_mvs, ' '.join(gpu_config)))
                         except:
                             log.ODM_WARNING("Sub-scene %s could not be reconstructed, skipping..." % sf)
 
@@ -177,7 +177,7 @@ class ODMOpenMVSStage(types.ODM_Stage):
                         '-i "%s"' % scene_dense,
                         "-v 0"
                     ]
-                    system.run('%s %s' % (context.omvs_densify_path, ' '.join(config + gpu_config)))
+                    system.run('"%s" %s' % (context.omvs_densify_path, ' '.join(config + gpu_config)))
                 else:
                     raise system.ExitException("Cannot find scene_dense.mvs, dense reconstruction probably failed. Exiting...")
 

--- a/win32env.bat
+++ b/win32env.bat
@@ -13,7 +13,7 @@ set GDALBASE=%ODMBASE%venv\Lib\site-packages\osgeo
 set OSFMBASE=%ODMBASE%SuperBuild\install\bin\opensfm\bin
 set SBBIN=%ODMBASE%SuperBuild\install\bin
 
-set PATH=%GDALBASE%;%SBBIN%;%OSFMBASE%
+set PATH="%GDALBASE%";"%SBBIN%";"%OSFMBASE%"
 set PROJ_LIB=%GDALBASE%\data\proj
 
 set VIRTUAL_ENV=%ODMBASE%venv


### PR DESCRIPTION
Small changes that should handle spaces in install path of ODM (should happened quite a lot on Windows).
Have been reported here : https://github.com/OpenDroneMap/ODM/issues/1317