### PR TITLE
Ignore resolution only if ignore_gsd

### DIFF
--- a/stages/odm_dem.py
+++ b/stages/odm_dem.py
@@ -36,7 +36,7 @@ class ODMDEMStage(types.ODM_Stage):
         resolution = gsd.cap_resolution(args.dem_resolution, tree.opensfm_reconstruction, 
                                         gsd_scaling=gsd_scaling,
                                         ignore_gsd=args.ignore_gsd,
-                                        ignore_resolution=ignore_resolution,
+                                        ignore_resolution=ignore_resolution and args.ignore_gsd,
                                         has_gcp=reconstruction.has_gcp())
 
         log.ODM_INFO('Classify: ' + str(args.pc_classify))

--- a/stages/odm_meshing.py
+++ b/stages/odm_meshing.py
@@ -44,7 +44,7 @@ class ODMeshingStage(types.ODM_Stage):
               log.ODM_INFO('Writing ODM 2.5D Mesh file in: %s' % tree.odm_25dmesh)
               ortho_resolution = gsd.cap_resolution(args.orthophoto_resolution, tree.opensfm_reconstruction, 
                                                     ignore_gsd=args.ignore_gsd,
-                                                    ignore_resolution=not reconstruction.is_georeferenced(),
+                                                    ignore_resolution=(not reconstruction.is_georeferenced()) and args.ignore_gsd,
                                                     has_gcp=reconstruction.has_gcp()) / 100.0 
               
               dsm_multiplier = max(1.0, gsd.rounded_gsd(tree.opensfm_reconstruction, default_value=4, ndigits=3, ignore_gsd=args.ignore_gsd))

--- a/stages/odm_orthophoto.py
+++ b/stages/odm_orthophoto.py
@@ -31,7 +31,7 @@ class ODMOrthoPhotoStage(types.ODM_Stage):
 
             resolution = 1.0 / (gsd.cap_resolution(args.orthophoto_resolution, tree.opensfm_reconstruction,
                                                    ignore_gsd=args.ignore_gsd,
-                                                   ignore_resolution=not reconstruction.is_georeferenced(),
+                                                   ignore_resolution=(not reconstruction.is_georeferenced()) and args.ignore_gsd,
                                                    has_gcp=reconstruction.has_gcp()) / 100.0)
 
             # odm_orthophoto definitions


### PR DESCRIPTION
Some non-georeferenced datasets explode in 2D output size under certain conditions. This prevents that from happening, unless ignore-gsd is set (which is to be used at one's own risk).﻿
