### PR TITLE
Improve OPK support for DJI

### DIFF
--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -338,7 +338,7 @@ class ODM_Photo:
                             self.camera_projection = camera_projection
 
                     # OPK
-                    self.set_attr_from_xmp_tag('yaw', tags, ['@drone-dji:GimbalYawDegree', '@Camera:Yaw', 'Camera:Yaw'], float)
+                    self.set_attr_from_xmp_tag('yaw', tags, ['@drone-dji:FlightYawDegree', '@Camera:Yaw', 'Camera:Yaw'], float)
                     self.set_attr_from_xmp_tag('pitch', tags, ['@drone-dji:GimbalPitchDegree', '@Camera:Pitch', 'Camera:Pitch'], float)
                     self.set_attr_from_xmp_tag('roll', tags, ['@drone-dji:GimbalRollDegree', '@Camera:Roll', 'Camera:Roll'], float)
 


### PR DESCRIPTION
Use the FlightYawDegree XMP tag instead of GimbalYawDegree.

GimbalYawDegree used to match the FlightYawDegree values closely, but newer models seem to (correctly) differentiate between the two.


