### PR TITLE
Finer default GSD for *-resolution parameters

### DIFF
--- a/opendm/config.py
+++ b/opendm/config.py
@@ -524,7 +524,7 @@ def config(argv=None, parser=None):
                         metavar='<float>',
                         action=StoreValue,
                         type=float,
-                        default=5,
+                        default=2.0,
                         help='DSM/DTM resolution in cm / pixel. Note that this value is capped by a ground sampling distance (GSD) estimate. To remove the cap, check --ignore-gsd also.'
                              ' Default: %(default)s')
 
@@ -550,7 +550,7 @@ def config(argv=None, parser=None):
     parser.add_argument('--orthophoto-resolution',
                         metavar='<float > 0.0>',
                         action=StoreValue,
-                        default=5,
+                        default=1.0,
                         type=float,
                         help=('Orthophoto resolution in cm / pixel. Note that this value is capped by a ground sampling distance (GSD) estimate. To remove the cap, check --ignore-gsd also. '
                               'Default: %(default)s'))


### PR DESCRIPTION
--orthophoto-resolution 1.0cm/px as default to match finest supported by Lightning, --dem-resolution 2.0cm/px to follow suggested best-practice of DEM being 1/2 to 1/4 of GSD.

This is prompted by numerous customer conversations stemming from confusion about output quality with Default processing profile in WebODM (or in the case of CLI, no parameters passed at all).

I would appreciate feedback on this change in terms of hardware requirement viability, processing time viability, appropriateness of changing the default here vs in the default processing profiles shipped with WebODM, whether or not --dem-resolution should track changes to --orthophoto-resolution 1:1 instead of 1:0.5 (or 1:0.25), etc.