### PR TITLE
More resiliant GPU feature detection

### DIFF
--- a/opendm/gpu.py
+++ b/opendm/gpu.py
@@ -20,6 +20,7 @@ def has_popsift_and_can_handle_texsize(width, height):
             return False
     except Exception as e:
         log.ODM_WARNING("Cannot use GPU for feature extraction: %s" % str(e))
+        return False
 
     try:
         from opensfm import pypopsift

--- a/opendm/gpu.py
+++ b/opendm/gpu.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import shutil
+import ctypes
 from opendm import log
 from repoze.lru import lru_cache
 
@@ -9,9 +10,20 @@ def gpu_disabled_by_user():
 
 @lru_cache(maxsize=None)
 def has_popsift_and_can_handle_texsize(width, height):
+    # We first check that we have the required compute capabilities
+    # As we do not support compute capabilities less than 3.5
+    try:
+        compute_major, compute_minor = get_cuda_compute_version(0)
+        if compute_major < 3 or (compute_major == 3 and compute_minor < 5):
+            # Not supported
+            log.ODM_WARNING("CUDA compute platform is not supported (detected: %s.%s but we need at least 3.5)" % (compute_major, compute_minor))
+            return False
+    except Exception as e:
+        log.ODM_WARNING("Cannot use GPU for feature extraction: %s" % str(e))
+
     try:
         from opensfm import pypopsift
-        fits = pypopsift.fits_texture(int(width * 1.025), int(height * 1.025))
+        fits = pypopsift.fits_texture(int(width * 1.02), int(height * 1.02))
         if not fits:
             log.ODM_WARNING("Image size (%sx%spx) would not fit in GPU memory, falling back to CPU" % (width, height))
         return fits
@@ -20,6 +32,40 @@ def has_popsift_and_can_handle_texsize(width, height):
     except Exception as e:
         log.ODM_WARNING(str(e))
         return False
+
+@lru_cache(maxsize=None)
+def get_cuda_compute_version(device_id = 0):
+    cuda_lib = "libcuda.so"
+    if sys.platform == 'win32':
+        cuda_lib = "nvcuda.dll"
+
+    nvcuda = ctypes.cdll.LoadLibrary(cuda_lib)
+
+    nvcuda.cuInit.argtypes = (ctypes.c_uint32, )
+    nvcuda.cuInit.restypes = (ctypes.c_int32)
+
+    if nvcuda.cuInit(0) != 0:
+        raise Exception("Cannot initialize CUDA")
+
+    nvcuda.cuDeviceGetCount.argtypes = (ctypes.POINTER(ctypes.c_int32), )
+    nvcuda.cuDeviceGetCount.restypes = (ctypes.c_int32)
+    
+    device_count = ctypes.c_int32()
+    if nvcuda.cuDeviceGetCount(ctypes.byref(device_count)) != 0:
+        raise Exception("Cannot get device count")
+
+    if device_count.value == 0:
+        raise Exception("No devices")
+
+    nvcuda.cuDeviceComputeCapability.argtypes = (ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.c_int32)
+    nvcuda.cuDeviceComputeCapability.restypes = (ctypes.c_int32)
+    compute_major = ctypes.c_int32()
+    compute_minor = ctypes.c_int32()
+
+    if nvcuda.cuDeviceComputeCapability(ctypes.byref(compute_major), ctypes.byref(compute_minor), device_id) != 0:
+        raise Exception("Cannot get CUDA compute version")
+
+    return (compute_major.value, compute_minor.value)
 
 @lru_cache(maxsize=None)
 def has_gpu():

--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -257,6 +257,7 @@ class OSFMContext:
                 if has_popsift_and_can_handle_texsize(w, h) and feature_type == "SIFT":
                     log.ODM_INFO("Using GPU for extracting SIFT features")
                     feature_type = "SIFT_GPU"
+                    self.gpu_sift_feature_extraction = True
             
             config.append("feature_type: %s" % feature_type)
 
@@ -361,7 +362,18 @@ class OSFMContext:
         matches_dir = self.path("matches")
         
         if not io.dir_exists(features_dir) or rerun:
-            self.run('detect_features')
+            try:
+                self.run('detect_features')
+            except SubprocessException as e:
+                # Sometimes feature extraction by GPU can fail
+                # for various reasons, so before giving up
+                # we try to fallback to CPU
+                if hasattr(self, 'gpu_sift_feature_extraction'):
+                    log.ODM_WARNING("GPU SIFT extraction failed, maybe your graphics card is too old, attempting fallback to CPU")
+                    self.update_config({'feature_type': "SIFT"})
+                    self.run('detect_features')
+                else:
+                    raise e
         else:
             log.ODM_WARNING('Detect features already done: %s exists' % features_dir)
 

--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -369,7 +369,7 @@ class OSFMContext:
                 # for various reasons, so before giving up
                 # we try to fallback to CPU
                 if hasattr(self, 'gpu_sift_feature_extraction'):
-                    log.ODM_WARNING("GPU SIFT extraction failed, maybe your graphics card is too old, attempting fallback to CPU")
+                    log.ODM_WARNING("GPU SIFT extraction failed, maybe the graphics card is not supported? Attempting fallback to CPU")
                     self.update_config({'feature_type': "SIFT"})
                     self.run('detect_features')
                 else:

--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -364,7 +364,7 @@ class OSFMContext:
         if not io.dir_exists(features_dir) or rerun:
             try:
                 self.run('detect_features')
-            except SubprocessException as e:
+            except system.SubprocessException as e:
                 # Sometimes feature extraction by GPU can fail
                 # for various reasons, so before giving up
                 # we try to fallback to CPU

--- a/opendm/system.py
+++ b/opendm/system.py
@@ -7,7 +7,6 @@ import subprocess
 import string
 import signal
 import io
-import ctypes
 from collections import deque
 
 from opendm import context
@@ -74,11 +73,8 @@ def run(cmd, env_paths=[context.superbuild_bin_path], env_vars={}, packages_path
     env = os.environ.copy()
 
     sep = ":"
-    flags = 0
     if sys.platform == 'win32':
         sep = ";"
-        ctypes.windll.kernel32.SetErrorMode(0x0002) #SEM_NOGPFAULTERRORBOX
-        flags = 0x8000000 #CREATE_NO_WINDOW
 
     if len(env_paths) > 0:
         env["PATH"] = env["PATH"] + sep + sep.join(env_paths)
@@ -89,7 +85,7 @@ def run(cmd, env_paths=[context.superbuild_bin_path], env_vars={}, packages_path
     for k in env_vars:
         env[k] = str(env_vars[k])
 
-    p = subprocess.Popen(cmd, shell=True, env=env, start_new_session=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, creationflags=flags)
+    p = subprocess.Popen(cmd, shell=True, env=env, start_new_session=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     running_subprocesses.append(p)
     lines = deque()
     for line in io.TextIOWrapper(p.stdout):

--- a/opendm/system.py
+++ b/opendm/system.py
@@ -7,6 +7,7 @@ import subprocess
 import string
 import signal
 import io
+import ctypes
 from collections import deque
 
 from opendm import context
@@ -73,8 +74,11 @@ def run(cmd, env_paths=[context.superbuild_bin_path], env_vars={}, packages_path
     env = os.environ.copy()
 
     sep = ":"
+    flags = 0
     if sys.platform == 'win32':
         sep = ";"
+        ctypes.windll.kernel32.SetErrorMode(0x0002) #SEM_NOGPFAULTERRORBOX
+        flags = 0x8000000 #CREATE_NO_WINDOW
 
     if len(env_paths) > 0:
         env["PATH"] = env["PATH"] + sep + sep.join(env_paths)
@@ -85,7 +89,7 @@ def run(cmd, env_paths=[context.superbuild_bin_path], env_vars={}, packages_path
     for k in env_vars:
         env[k] = str(env_vars[k])
 
-    p = subprocess.Popen(cmd, shell=True, env=env, start_new_session=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    p = subprocess.Popen(cmd, shell=True, env=env, start_new_session=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, creationflags=flags)
     running_subprocesses.append(p)
     lines = deque()
     for line in io.TextIOWrapper(p.stdout):


### PR DESCRIPTION
Should close #1425

@Saijin-Naib could you please apply this patch to your native install of ODM where the GPU process was crashing and report back if the program successfully falls back to CPU in those cases? :pray:

The console should read: `GPU SIFT extraction failed, maybe the graphics card is not supported? Attempting fallback to CPU`

﻿
