### PR TITLE
fix:  Adding quotes around pycfg file for hot-patching

### DIFF
--- a/win32env.bat
+++ b/win32env.bat
@@ -21,8 +21,8 @@ set PYTHONPATH=%VIRTUAL_ENV%
 set PYENVCFG=%VIRTUAL_ENV%\pyvenv.cfg
 
 rem Hot-patching pyvenv.cfg
-echo home = %ODMBASE%\python38> %PYENVCFG%
-echo include-system-site-packages = false>> %PYENVCFG%
+echo home = %ODMBASE%\python38> "%PYENVCFG%"
+echo include-system-site-packages = false>> "%PYENVCFG%"
 
 rem Hot-patching cv2 extension configs
 echo BINARIES_PATHS = [r"%SBBIN%"] + BINARIES_PATHS> venv\Lib\site-packages\cv2\config.py


### PR DESCRIPTION
Hopefully the correct fix this time for this bug https://github.com/OpenDroneMap/ODM/issues/1317

Without quote the >> operator will cut the destination path from begin to first space resulting in a new file being created instead of the correct config file being patch.