### PR TITLE
mod:  forcing python to use utf8

### DIFF
--- a/winrun.bat
+++ b/winrun.bat
@@ -3,7 +3,7 @@
 setlocal
 
 call win32env.bat
-python "%ODMBASE%\run.py" %*
+python -X utf8 "%ODMBASE%\run.py" %*
 
 endlocal
 


### PR DESCRIPTION
This should fix two issues as discussed [here](https://community.opendronemap.org/t/non-ascii-character-in-odm-install-path/11020)

- If there are non ascii characters in the ODM install path opencv loading fails thus preventing ODM from working
- If there are non ascci characters in projet path other errors are raised.

