### PR TITLE
--dem-resolution note

### DIFF
--- a/opendm/config.py
+++ b/opendm/config.py
@@ -536,7 +536,7 @@ def config(argv=None, parser=None):
                         action=StoreValue,
                         type=float,
                         default=5,
-                        help='DSM/DTM resolution in cm / pixel. Note that this value is capped by a ground sampling distance (GSD) estimate. To remove the cap, check --ignore-gsd also.'
+                        help='DSM/DTM resolution in cm / pixel. Note that this value is locked to 2x the ground sampling distance (GSD) estimate. To remove the cap, check --ignore-gsd also.'
                              ' Default: %(default)s')
 
     parser.add_argument('--dem-decimation',

--- a/opendm/config.py
+++ b/opendm/config.py
@@ -536,7 +536,7 @@ def config(argv=None, parser=None):
                         action=StoreValue,
                         type=float,
                         default=5,
-                        help='DSM/DTM resolution in cm / pixel. Note that this value is locked to 2x the ground sampling distance (GSD) estimate. To remove the cap, check --ignore-gsd also.'
+                        help='DSM/DTM resolution in cm / pixel. Note: This value is locked to at least 2x the ground sampling distance (GSD) estimate. To remove the cap, check --ignore-gsd also.'
                              ' Default: %(default)s')
 
     parser.add_argument('--dem-decimation',


### PR DESCRIPTION
Explain that it is capped to at least 2x the GSD estimate to clarify usage and reduce user confusion.