### PR TITLE
fix: osfm elevation check

### DIFF
--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -148,17 +148,25 @@ class OSFMContext:
                 photos = reconstruction.photos
 
             # create file list
+            num_zero_alt = 0
             has_alt = True
             has_gps = False
             with open(list_path, 'w') as fout:
                 for photo in photos:
                     if photo.altitude is None:
                         has_alt = False
+                    elif photo.altitude == 0:
+                        num_zero_alt += 1
                     if photo.latitude is not None and photo.longitude is not None:
                         has_gps = True
 
                     fout.write('%s\n' % os.path.join(images_path, photo.filename))
             
+            # check 0 altitude images percentage when has_alt is True
+            if has_alt and num_zero_alt / len(photos) > 0.05:
+                log.ODM_WARNING("More than 5% of images have zero altitude, this might be an indicator that the images have no altitude information")
+                has_alt = False
+
             # check for image_groups.txt (split-merge)
             image_groups_file = os.path.join(args.project_path, "image_groups.txt")
             if 'split_image_groups_is_set' in args:

--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -152,7 +152,7 @@ class OSFMContext:
             has_gps = False
             with open(list_path, 'w') as fout:
                 for photo in photos:
-                    if not photo.altitude:
+                    if photo.altitude is None:
                         has_alt = False
                     if photo.latitude is not None and photo.longitude is not None:
                         has_gps = True


### PR DESCRIPTION
Fix #1480. By default, `photo.altitude` will be None if no altitude in photo EXIF. And I didn't find a place to explicitly set its value to 0 to indicate it doesn't exist. I assume it's safe to check if it's None.