### PR TITLE
Add readout for TeraCube TeraCube_One Mobile Phone

### DIFF
--- a/opendm/rollingshutter.py
+++ b/opendm/rollingshutter.py
@@ -19,6 +19,8 @@ RS_DATABASE = {
     'gopro hero4 black': 30, # GoPro Hero 4 Black
     'gopro hero8 black': 17 # GoPro Hero 8 Black
 
+    'teracube teracube one': 32, # TeraCube TeraCube_One TR1907Q Mobile Phone
+    
     # Help us add more! 
     # See: https://github.com/OpenDroneMap/RSCalibration for instructions
 }

--- a/opendm/rollingshutter.py
+++ b/opendm/rollingshutter.py
@@ -17,9 +17,9 @@ RS_DATABASE = {
     'dji fc350': 30, # Inspire 1
 
     'gopro hero4 black': 30, # GoPro Hero 4 Black
-    'gopro hero8 black': 17 # GoPro Hero 8 Black
+    'gopro hero8 black': 17, # GoPro Hero 8 Black
 
-    'teracube teracube one': 32, # TeraCube TeraCube_One TR1907Q Mobile Phone
+    'teracube teracube one': 32 # TeraCube TeraCube_One TR1907Q Mobile Phone
     
     # Help us add more! 
     # See: https://github.com/OpenDroneMap/RSCalibration for instructions


### PR DESCRIPTION
My current mobile phone that I use for all of my ground-based data collection and reconstruction.

Not a fantastic sensor (Samsung S5K2L8SX 12MP), but device has full source available at least and OpenCamera writes full Y/P/R into EXIF :D

Example:  
![image](https://user-images.githubusercontent.com/19295950/175454991-8863c6db-833d-42e0-b8ae-1fc88ec44e1a.png)