### PR TITLE
INFO message for camera make/model/readout

### DIFF
--- a/opendm/rollingshutter.py
+++ b/opendm/rollingshutter.py
@@ -30,6 +30,7 @@ def make_model_key(make, model):
     return ("%s %s" % (make.strip(), model.strip())).lower().strip()
 
 warn_db_missing = {}
+info_db_found = {}
 
 def get_rolling_shutter_readout(make, model, override_value=0):
     global warn_db_missing
@@ -39,8 +40,9 @@ def get_rolling_shutter_readout(make, model, override_value=0):
     
     key = make_model_key(make, model)
     if key in RS_DATABASE:
-        log.ODM_INFO("Rolling shutter profile for \"%s %s\" selected, using %sms as --rolling-shutter-readout." % (make, model, RS_DATABASE[key]))
-        warn_db_missing[key] = False
+        if not key in info_db_found:
+            log.ODM_INFO("Rolling shutter profile for \"%s %s\" selected, using %sms as --rolling-shutter-readout." % (make, model, RS_DATABASE[key]))
+            info_db_found[key] = True
         return float(RS_DATABASE[key])
     else:
         # Warn once

--- a/opendm/rollingshutter.py
+++ b/opendm/rollingshutter.py
@@ -34,6 +34,7 @@ info_db_found = {}
 
 def get_rolling_shutter_readout(make, model, override_value=0):
     global warn_db_missing
+    global info_db_found
 
     if override_value > 0:
         return override_value

--- a/opendm/rollingshutter.py
+++ b/opendm/rollingshutter.py
@@ -39,6 +39,8 @@ def get_rolling_shutter_readout(make, model, override_value=0):
     
     key = make_model_key(make, model)
     if key in RS_DATABASE:
+        log.ODM_INFO("Rolling shutter profile for \"%s %s\" selected, using %sms as --rolling-shutter-readout." % (make, model, RS_DATABASE[key]))
+        warn_db_missing[key] = False
         return float(RS_DATABASE[key])
     else:
         # Warn once


### PR DESCRIPTION
This currently prints once per image in the Task so it gets noisy on the console.
![image](https://user-images.githubusercontent.com/19295950/176332782-81b98e8d-bf17-437a-881b-bc4719cf793e.png)
I could use some help cleaning this up, if possible.