### PR TITLE
Add Air2S to rollingshutter.py

### DIFF
--- a/opendm/rollingshutter.py
+++ b/opendm/rollingshutter.py
@@ -13,6 +13,7 @@ RS_DATABASE = {
 
     'dji fc7203': 20, # Mavic Mini v1
     'dji fc3170': 27, # DJI Mavic Air 2
+    'dji fc3411': 32, # DJI Mavic Air 2S
 
     'dji fc350': 30, # Inspire 1
 


### PR DESCRIPTION

![Photo_6554591_DJI_991_jpg_3654362_0_202272017152_photo_original jpg](https://user-images.githubusercontent.com/109701696/180092827-861e5f93-987c-455b-86c9-b73c31e9c97c.JPG)
As measured using https://github.com/OpenDroneMap/RSCalibration