### PR TITLE
Faster orthophoto rendering, remove PCL

### DIFF
--- a/SuperBuild/CMakeLists.txt
+++ b/SuperBuild/CMakeLists.txt
@@ -99,15 +99,6 @@ SETUP_EXTERNAL_PROJECT(OpenCV ${ODM_OpenCV_Version} ${ODM_BUILD_OpenCV})
 
 
 # ---------------------------------------------------------------------------------------------
-# Point Cloud Library (PCL)
-#
-set(ODM_PCL_Version 1.8.0)
-option(ODM_BUILD_PCL "Force to build PCL library" OFF)
-
-SETUP_EXTERNAL_PROJECT(PCL ${ODM_PCL_Version} ${ODM_BUILD_PCL})
-
-
-# ---------------------------------------------------------------------------------------------
 # Google Flags library (GFlags)
 #
 set(ODM_GFlags_Version 2.1.2)
@@ -201,9 +192,9 @@ externalproject_add(dem2points
 )
 
 externalproject_add(odm_orthophoto
-    DEPENDS           pcl opencv 
+    DEPENDS           opencv 
     GIT_REPOSITORY    https://github.com/OpenDroneMap/odm_orthophoto.git
-    GIT_TAG           main
+    GIT_TAG           288a
     PREFIX            ${SB_BINARY_DIR}/odm_orthophoto
     SOURCE_DIR        ${SB_SOURCE_DIR}/odm_orthophoto
     CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX:PATH=${SB_INSTALL_DIR}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,7 +37,6 @@ parts:
       - gdal-bin
       - gfortran # to build scipy
       - git
-      - libboost-log-dev
       - libgdal-dev
       - libgeotiff-dev
       - libjsoncpp-dev
@@ -54,7 +53,6 @@ parts:
       - swig3.0
     stage-packages:
       - gdal-bin
-      - libboost-log1.71.0
       - libgdal26
       - libgeotiff5
       - libjsoncpp1
@@ -114,33 +112,23 @@ parts:
     build-packages:
       - libcgal-dev
       - libboost-program-options-dev
+      - libboost-iostreams-dev
+      - libboost-serialization-dev
+      - libboost-system-dev
     stage-packages:
       - libboost-program-options1.71.0
+      - libboost-iostreams1.71.0
+      - libboost-serialization1.71.0
+      - libboost-system1.71.0
 
   opensfm:
     source: .
     plugin: nil
     build-packages:
-      - libboost-date-time-dev
-      - libboost-filesystem-dev
-      - libboost-iostreams-dev
-      - libboost-python-dev
-      - libboost-regex-dev
-      - libboost-serialization-dev
-      - libboost-system-dev
-      - libboost-thread-dev
       - libgoogle-glog-dev
       - libsuitesparse-dev
     stage-packages:
       - libamd2
-      - libboost-date-time1.71.0
-      - libboost-filesystem1.71.0
-      - libboost-iostreams1.71.0
-      - libboost-python1.71.0
-      - libboost-regex1.71.0
-      - libboost-serialization1.71.0
-      - libboost-system1.71.0
-      - libboost-thread1.71.0
       - libcamd2
       - libccolamd2
       - libcholmod3

--- a/snap/snapcraft21.yaml
+++ b/snap/snapcraft21.yaml
@@ -37,7 +37,6 @@ parts:
       - gdal-bin
       - gfortran # to build scipy
       - git
-      - libboost-log-dev
       - libgdal-dev
       - libgeotiff-dev
       - libjsoncpp-dev
@@ -54,7 +53,6 @@ parts:
       - swig3.0
     stage-packages:
       - gdal-bin
-      - libboost-log1.74.0
       - libgdal28
       - libgeotiff5
       - libjsoncpp24
@@ -114,33 +112,23 @@ parts:
     build-packages:
       - libcgal-dev
       - libboost-program-options-dev
+      - libboost-iostreams-dev
+      - libboost-serialization-dev
+      - libboost-system-dev
     stage-packages:
       - libboost-program-options1.74.0
+      - libboost-iostreams1.74.0
+      - libboost-serialization1.74.0
+      - libboost-system1.74.0
 
   opensfm:
     source: .
     plugin: nil
     build-packages:
-      - libboost-date-time-dev
-      - libboost-filesystem-dev
-      - libboost-iostreams-dev
-      - libboost-python-dev
-      - libboost-regex-dev
-      - libboost-serialization-dev
-      - libboost-system-dev
-      - libboost-thread-dev
       - libgoogle-glog-dev
       - libsuitesparse-dev
     stage-packages:
       - libamd2
-      - libboost-date-time1.74.0
-      - libboost-filesystem1.74.0
-      - libboost-iostreams1.74.0
-      - libboost-python1.74.0
-      - libboost-regex1.74.0
-      - libboost-serialization1.74.0
-      - libboost-system1.74.0
-      - libboost-thread1.74.0
       - libcamd2
       - libccolamd2
       - libcholmod3


### PR DESCRIPTION
 - Faster `odm_orthophoto`
 - ﻿Removes the dependency to PCL
