### PR TITLE
Use old-releases for 21.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opendronemap/ubuntu:21.04 AS builder
+FROM ubuntu:21.04 AS builder
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -11,6 +11,9 @@ WORKDIR /code
 # Copy everything
 COPY . ./
 
+# Use old-releases for 21.04
+RUN printf "deb http://old-releases.ubuntu.com/ubuntu/ hirsute main restricted\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-updates main restricted\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute universe\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-updates universe\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute multiverse\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-updates multiverse\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-backports main restricted universe multiverse" > /etc/apt/sources.list
+
 # Run the build
 RUN bash configure.sh install
 
@@ -21,7 +24,7 @@ RUN bash configure.sh clean
 
 ### Use a second image for the final asset to reduce the number and
 # size of the layers.
-FROM opendronemap/ubuntu:21.04
+FROM ubuntu:21.04
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -35,6 +38,9 @@ COPY --from=builder /code /code
 
 # Copy the Python libraries installed via pip from the builder
 COPY --from=builder /usr/local /usr/local
+
+# Use old-releases for 21.04
+RUN printf "deb http://old-releases.ubuntu.com/ubuntu/ hirsute main restricted\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-updates main restricted\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute universe\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-updates universe\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute multiverse\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-updates multiverse\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-backports main restricted universe multiverse" > /etc/apt/sources.list
 
 # Install shared libraries that we depend on via APT, but *not*
 # the -dev packages to save space!

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04 AS builder
+FROM opendronemap/ubuntu:21.04 AS builder
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -21,7 +21,7 @@ RUN bash configure.sh clean
 
 ### Use a second image for the final asset to reduce the number and
 # size of the layers.
-FROM ubuntu:21.04
+FROM opendronemap/ubuntu:21.04
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/portable.Dockerfile
+++ b/portable.Dockerfile
@@ -1,4 +1,4 @@
-FROM opendronemap/ubuntu:21.04 AS builder
+FROM ubuntu:21.04 AS builder
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -11,6 +11,9 @@ WORKDIR /code
 # Copy everything
 COPY . ./
 
+# Use old-releases for 21.04
+RUN printf "deb http://old-releases.ubuntu.com/ubuntu/ hirsute main restricted\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-updates main restricted\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute universe\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-updates universe\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute multiverse\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-updates multiverse\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-backports main restricted universe multiverse" > /etc/apt/sources.list
+
 # Run the build
 RUN PORTABLE_INSTALL=YES bash configure.sh install
 
@@ -21,7 +24,7 @@ RUN bash configure.sh clean
 
 ### Use a second image for the final asset to reduce the number and
 # size of the layers.
-FROM opendronemap/ubuntu:21.04
+FROM ubuntu:21.04
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -35,6 +38,9 @@ COPY --from=builder /code /code
 
 # Copy the Python libraries installed via pip from the builder
 COPY --from=builder /usr/local /usr/local
+
+# Use old-releases for 21.04
+RUN printf "deb http://old-releases.ubuntu.com/ubuntu/ hirsute main restricted\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-updates main restricted\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute universe\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-updates universe\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute multiverse\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-updates multiverse\ndeb http://old-releases.ubuntu.com/ubuntu/ hirsute-backports main restricted universe multiverse" > /etc/apt/sources.list
 
 # Install shared libraries that we depend on via APT, but *not*
 # the -dev packages to save space!

--- a/portable.Dockerfile
+++ b/portable.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04 AS builder
+FROM opendronemap/ubuntu:21.04 AS builder
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -21,7 +21,7 @@ RUN bash configure.sh clean
 
 ### Use a second image for the final asset to reduce the number and
 # size of the layers.
-FROM ubuntu:21.04
+FROM opendronemap/ubuntu:21.04
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Use `old-releases` for `21.04` until we can upgrade to `22.04`.