### PR TITLE
Support for RGB+Multispec image inputs

### DIFF
--- a/SuperBuild/CMakeLists.txt
+++ b/SuperBuild/CMakeLists.txt
@@ -194,7 +194,7 @@ externalproject_add(dem2points
 externalproject_add(odm_orthophoto
     DEPENDS           opencv 
     GIT_REPOSITORY    https://github.com/OpenDroneMap/odm_orthophoto.git
-    GIT_TAG           288a
+    GIT_TAG           288b
     PREFIX            ${SB_BINARY_DIR}/odm_orthophoto
     SOURCE_DIR        ${SB_SOURCE_DIR}/odm_orthophoto
     CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX:PATH=${SB_INSTALL_DIR}

--- a/SuperBuild/cmake/External-OpenMVS.cmake
+++ b/SuperBuild/cmake/External-OpenMVS.cmake
@@ -52,7 +52,7 @@ ExternalProject_Add(${_proj_name}
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
   GIT_REPOSITORY    https://github.com/OpenDroneMap/openMVS
-  GIT_TAG           287
+  GIT_TAG           288
   #--Update/Patch step----------
   UPDATE_COMMAND    ""
   #--Configure step-------------

--- a/SuperBuild/cmake/External-OpenSfM.cmake
+++ b/SuperBuild/cmake/External-OpenSfM.cmake
@@ -19,7 +19,7 @@ ExternalProject_Add(${_proj_name}
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
   GIT_REPOSITORY    https://github.com/OpenDroneMap/OpenSfM/
-  GIT_TAG           287
+  GIT_TAG           288
   #--Update/Patch step----------
   UPDATE_COMMAND    git submodule update --init --recursive
   #--Configure step-------------

--- a/opendm/multispectral.py
+++ b/opendm/multispectral.py
@@ -56,7 +56,9 @@ def dn_to_radiance(photo, image):
     bit_depth_max = photo.get_bit_depth_max()
     if bit_depth_max:
         image /= bit_depth_max
-
+    else:
+        log.ODM_WARNING("Cannot normalize DN for %s, bit depth is missing" % photo.filename)
+    
     if V is not None:
         # vignette correction
         V = np.repeat(V[:, :, np.newaxis], image.shape[2], axis=2)

--- a/opendm/orthophoto.py
+++ b/opendm/orthophoto.py
@@ -56,6 +56,9 @@ def generate_png(orthophoto_file, output_file=None, outsize=None):
             red = bands.get(gdal.GCI_RedBand)
             green = bands.get(gdal.GCI_GreenBand)
             blue = bands.get(gdal.GCI_BlueBand)
+            if red is None or green is None or blue is None:
+                raise Exception("Cannot find bands")
+
             bandparam = "-b %s -b %s -b %s -a_nodata 0" % (red, green, blue)
         except:
             bandparam = "-b 1 -b 2 -b 3 -a_nodata 0"

--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -725,8 +725,11 @@ class ODM_Photo:
 
     def is_thermal(self):
         #Added for support M2EA camera sensor
-        if(self.camera_make == "DJI"):
-            return self.camera_model == "MAVIC2-ENTERPRISE-ADVANCED" and self.width == 640 and self.height == 512
+        if(self.camera_make == "DJI" and self.camera_model == "MAVIC2-ENTERPRISE-ADVANCED" and self.width == 640 and self.height == 512):
+            return True
+        #Added for support DJI H20T camera sensor
+        if(self.camera_make == "DJI" and self.camera_model == "ZH20T" and self.width == 640 and self.height == 512):
+            return True
         return self.band_name.upper() in ["LWIR"] # TODO: more?
 
     def camera_id(self):

--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -256,10 +256,10 @@ class ODM_Photo:
                     self.iso_speed = self.int_value(tags['EXIF PhotographicSensitivity'])
                 elif 'EXIF ISOSpeedRatings' in tags:
                     self.iso_speed = self.int_value(tags['EXIF ISOSpeedRatings'])
-                    
-
+                
                 if 'Image BitsPerSample' in tags:
                     self.bits_per_sample = self.int_value(tags['Image BitsPerSample'])
+
                 if 'EXIF DateTimeOriginal' in tags:
                     str_time = tags['EXIF DateTimeOriginal'].values
                     utc_time = datetime.strptime(str_time, "%Y:%m:%d %H:%M:%S")
@@ -626,7 +626,7 @@ class ODM_Photo:
             if len(parts) == 3:
                 return list(map(float, parts))
 
-        return [None, None, None]                
+        return [None, None, None]
     
     def get_dark_level(self):
         if self.black_level:
@@ -695,6 +695,11 @@ class ODM_Photo:
     def get_bit_depth_max(self):
         if self.bits_per_sample:
             return float(2 ** self.bits_per_sample)
+        else:
+            # If it's a JPEG, this must be 256
+            _, ext = os.path.splitext(self.filename)
+            if ext.lower() in [".jpeg", ".jpg"]:
+                return 256.0
 
         return None
 
@@ -731,6 +736,9 @@ class ODM_Photo:
         if(self.camera_make == "DJI" and self.camera_model == "ZH20T" and self.width == 640 and self.height == 512):
             return True
         return self.band_name.upper() in ["LWIR"] # TODO: more?
+    
+    def is_rgb(self):
+        return self.band_name.upper() in ["RGB", "REDGREENBLUE"]
 
     def camera_id(self):
         return " ".join(

--- a/opendm/rollingshutter.py
+++ b/opendm/rollingshutter.py
@@ -48,7 +48,7 @@ def get_rolling_shutter_readout(photo, override_value=0):
     key = make_model_key(make, model)
     if key in RS_DATABASE:
         rsd = RS_DATABASE[key]
-        val = 0.0
+        val = DEFAULT_RS_READOUT
 
         if isinstance(rsd, int) or isinstance(rsd, float):
             val = float(rsd)

--- a/opendm/thermal.py
+++ b/opendm/thermal.py
@@ -1,6 +1,7 @@
 from opendm import log
 from opendm.thermal_tools import dji_unpack
 import cv2
+import os
 
 def resize_to_match(image, match_photo = None):
     """
@@ -39,6 +40,16 @@ def dn_to_temperature(photo, image, dataset_tree):
             image -= (273.15 * 100.0) # Convert Kelvin to Celsius
             image *= 0.01
             return image
+        elif photo.camera_make == "DJI" and photo.camera_model == "ZH20T":            
+            filename, file_extension = os.path.splitext(photo.filename)
+            # DJI H20T high gain mode supports measurement of -40~150 celsius degrees
+            if file_extension.lower() in ["tif", "tiff"] and image.min() >= 23315: # Calibrated grayscale tif
+                image = image.astype("float32")
+                image -= (273.15 * 100.0) # Convert Kelvin to Celsius
+                image *= 0.01
+                return image
+            else:
+                return image
         elif photo.camera_make == "DJI" and photo.camera_model == "MAVIC2-ENTERPRISE-ADVANCED":
             image = dji_unpack.extract_temperatures_dji(photo, image, dataset_tree)
             image = image.astype("float32")

--- a/opendm/thermal.py
+++ b/opendm/thermal.py
@@ -43,7 +43,7 @@ def dn_to_temperature(photo, image, dataset_tree):
         elif photo.camera_make == "DJI" and photo.camera_model == "ZH20T":            
             filename, file_extension = os.path.splitext(photo.filename)
             # DJI H20T high gain mode supports measurement of -40~150 celsius degrees
-            if file_extension.lower() in ["tif", "tiff"] and image.min() >= 23315: # Calibrated grayscale tif
+            if file_extension.lower() in [".tif", ".tiff"] and image.min() >= 23315: # Calibrated grayscale tif
                 image = image.astype("float32")
                 image -= (273.15 * 100.0) # Convert Kelvin to Celsius
                 image *= 0.01


### PR DESCRIPTION
Adds support for processing mixed RGB+Multispectral image inputs (e.g. Phantom 4 Multispectral files), you can now throw JPEGs (8bit) and TIFFs (16bit) and the dataset will process correctly.

You can also provide redundant data (RGB JPEGs + R/G/B TIFFs) and ODM will handle that gracefully.

Still need to add support for better radiometric calibration in these cases (byte to float conversion will currently still fail). Will try to improve that in the upcoming days.

