### PR TITLE
Added a warning before split-merge to ensure GPS/`image_groups.txt` info is present.

### DIFF
--- a/opendm/types.py
+++ b/opendm/types.py
@@ -93,6 +93,13 @@ class ODM_Reconstruction(object):
 
     def has_gcp(self):
         return self.is_georeferenced() and self.gcp is not None and self.gcp.exists()
+    
+    def has_geotagged_photos(self):
+        for photo in self.photos:
+            if photo.latitude is None and photo.longitude is None:
+                return False
+
+        return True 
 
     def georeference_with_gcp(self, gcp_file, output_coords_file, output_gcp_file, output_model_txt_geo, rerun=False):
         if not io.file_exists(output_coords_file) or not io.file_exists(output_gcp_file) or rerun:

--- a/stages/splitmerge.py
+++ b/stages/splitmerge.py
@@ -35,9 +35,13 @@ class ODMSplitStage(types.ODM_Stage):
         if io.file_exists(image_groups_file) or reconstruction.has_geotagged_photos():
             gps_info_available = True
 
-        outputs['large'] = len(photos) > args.split
+        should_split = len(photos) > args.split
+        if should_split and not gps_info_available:
+            log.ODM_WARNING('Could not perform split-merge as GPS information in photos or image_groups.txt is missing.')
 
-        if outputs['large'] and gps_info_available:
+        outputs['large'] = should_split and gps_info_available
+
+        if outputs['large']:
             # If we have a cluster address, we'll use a distributed workflow
             local_workflow = not bool(args.sm_cluster)
 
@@ -180,9 +184,6 @@ class ODMSplitStage(types.ODM_Stage):
             else:
                 log.ODM_WARNING('Found a split done file in: %s' % split_done_file)
         else:
-            if not gps_info_available:
-                log.ODM_WARNING('Could not perform split-merge as GPS information in photos or image_groups.txt is missing.')
-
             log.ODM_INFO("Normal dataset, will process all at once.")
             self.progress = 0.0
 


### PR DESCRIPTION
Fixes #1012 

This adds a check before initiating `split-merge` to see if either GPS info in photos or `image_groups.txt` is available. If not, it skips `split-merge` and proceeds with a warning.