### PR TITLE
fix:  Using triple quotes for multiline string in order to escape sim…

### DIFF
--- a/win32env.bat
+++ b/win32env.bat
@@ -26,7 +26,7 @@ echo include-system-site-packages = false>> %PYENVCFG%
 
 rem Hot-patching cv2 extension configs
 echo BINARIES_PATHS = [r"%SBBIN%"] + BINARIES_PATHS> venv\Lib\site-packages\cv2\config.py
-echo PYTHON_EXTENSIONS_PATHS = [r'%VIRTUAL_ENV%\lib\site-packages\cv2\python-3.8'] + PYTHON_EXTENSIONS_PATHS> venv\Lib\site-packages\cv2\config-3.8.py
+echo PYTHON_EXTENSIONS_PATHS = [r'''%VIRTUAL_ENV%\lib\site-packages\cv2\python-3.8'''] + PYTHON_EXTENSIONS_PATHS> venv\Lib\site-packages\cv2\config-3.8.py
 
 if not defined PROMPT set PROMPT=$P$G
 


### PR DESCRIPTION
"Using triple quotes for multiline string in order to escape simple quote inside PYTHON_EXTENSIONS_PATHS due to single quote in the ODMBASE path"

Should solve https://github.com/OpenDroneMap/ODM/issues/1492#issuecomment-1221524467