### PR TITLE
Remove dependency to onnx

### DIFF
--- a/opendm/skyremoval/skyfilter.py
+++ b/opendm/skyremoval/skyfilter.py
@@ -3,7 +3,6 @@ import time
 import numpy as np
 import cv2
 import os
-import onnx
 import onnxruntime as ort
 from .guidedfilter import guided_filter
 from opendm import log
@@ -27,17 +26,6 @@ class SkyFilter():
     
     def load_model(self):
         log.ODM_INFO(' -> Loading the model')
-        onnx_model = onnx.load(self.model)
-
-        # Check the model
-        try:
-            onnx.checker.check_model(onnx_model)
-        except onnx.checker.ValidationError as e:
-            log.ODM_INFO(' !> The model is invalid: %s' % e)
-            raise
-        else:
-            log.ODM_INFO(' ?> The model is valid!')
-
         self.session = ort.InferenceSession(self.model, providers=[provider])     
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,5 +29,4 @@ scipy==1.5.4
 xmltodict==0.12.0
 fpdf2==2.4.6
 Shapely==1.7.1
-onnx==1.12.0
-onnxruntime==1.11.1
+onnxruntime==1.12.1


### PR DESCRIPTION
Reduces install size, we don't actually need the `onnx` package (just the runtime).