### PR TITLE
Fix improper depthmap resolution parameter

### DIFF
--- a/SuperBuild/cmake/External-OpenMVS.cmake
+++ b/SuperBuild/cmake/External-OpenMVS.cmake
@@ -53,7 +53,7 @@ ExternalProject_Add(${_proj_name}
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
   GIT_REPOSITORY    https://github.com/OpenDroneMap/openMVS
-  GIT_TAG           291
+  GIT_TAG           300
   #--Update/Patch step----------
   UPDATE_COMMAND    ""
   #--Configure step-------------

--- a/stages/openmvs.py
+++ b/stages/openmvs.py
@@ -65,7 +65,6 @@ class ODMOpenMVSStage(types.ODM_Stage):
             config = [
                 " --resolution-level %s" % int(resolution_level),
                 '--dense-config-file "%s"' % densify_ini_file,
-                "--min-resolution %s" % depthmap_resolution,
                 "--max-resolution %s" % int(outputs['undist_image_max_size']),
                 "--max-threads %s" % args.max_concurrency,
                 "--number-views-fuse %s" % number_views_fuse,
@@ -158,7 +157,6 @@ class ODMOpenMVSStage(types.ODM_Stage):
                         # Fuse
                         config = [
                             '--resolution-level %s' % int(resolution_level),
-                            '--min-resolution %s' % depthmap_resolution,
                             '--max-resolution %s' % int(outputs['undist_image_max_size']),
                             '--dense-config-file "%s"' % subscene_densify_ini_file,
                             '--number-views-fuse %s' % number_views_fuse,

--- a/stages/openmvs.py
+++ b/stages/openmvs.py
@@ -77,8 +77,8 @@ class ODMOpenMVSStage(types.ODM_Stage):
             gpu_config = []
             use_gpu = has_gpu(args)
             if use_gpu:
-                #gpu_config.append("--cuda-device -3")
-                gpu_config.append("--cuda-device -1")
+                gpu_config.append("--cuda-device -3")
+                # gpu_config.append("--cuda-device -1")
             else:
                 gpu_config.append("--cuda-device -2")
 


### PR DESCRIPTION
Found this while performing some tests with higher `orthophoto-resolution` parameters. It turns out we should not set `--min-resolution` when calling OpenMVS, as we push the threshold for scaling images lower than the recommended value of `640` (OpenMVS's default).

