### PR TITLE
Update rollingshutter.py

### DIFF
--- a/opendm/rollingshutter.py
+++ b/opendm/rollingshutter.py
@@ -15,6 +15,7 @@ RS_DATABASE = {
     'dji fc3170': 27, # DJI Mavic Air 2
     'dji fc3411': 32, # DJI Mavic Air 2S
     
+    'dji fc220': 64, # DJI Mavic Pro (Platinum)
     'hasselblad l1d-20c': lambda p: 47 if p.get_capture_megapixels() < 17 else 56, # DJI Mavic 2 Pro (at 16:10 => 16.8MP 47ms, at 3:2 => 19.9MP 56ms. 4:3 has 17.7MP with same image height as 3:2 which can be concluded as same sensor readout)
 
     'dji fc3582': lambda p: 26 if p.get_capture_megapixels() < 48 else 60, # DJI Mini 3 pro (at 48MP readout is 60ms, at 12MP it's 26ms) 


### PR DESCRIPTION
Added calibration value for Mavic Pro (=64). Value is valid for both Mavic Pro and Mavic Pro Platinum, as both use camera 'DJI FC220'