### PR TITLE
feat: added "DJI Mavic Air (1)" to rollingshutter.py

### DIFF
--- a/opendm/rollingshutter.py
+++ b/opendm/rollingshutter.py
@@ -12,6 +12,7 @@ RS_DATABASE = {
     'dji fc6310': 33, # Phantom 4 Professional
 
     'dji fc7203': 20, # Mavic Mini v1
+    'dji fc2103': 32, # DJI Mavic Air 1
     'dji fc3170': 27, # DJI Mavic Air 2
     'dji fc3411': 32, # DJI Mavic Air 2S
     


### PR DESCRIPTION
Added the "DJI Mavic Air (1)" to the rolling shutter database. Camera is shown as "fc2103" and max shutter speed was 1/8000. I counted 32 lines on 3 different pictures, see one of them below.

![MavicAir1_1_8000](https://user-images.githubusercontent.com/6372605/209439965-81a87548-99b1-4544-a656-4929f8e3e809.JPG)

PS: Thanks for the awesome work and fantastic tool !