### PR TITLE
Don't let PDAL resolve canonical paths while searching for drivers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ FROM ubuntu:21.04
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.9:/code/SuperBuild/install/lib/python3.8/dist-packages:/code/SuperBuild/install/bin/opensfm" \
-    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib"
+    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib" \
+    PDAL_DRIVER_PATH="/code/SuperBuild/install/bin"
 
 WORKDIR /code
 

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -27,7 +27,8 @@ FROM nvidia/cuda:11.2.0-runtime-ubuntu20.04
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.9/dist-packages:/code/SuperBuild/install/lib/python3.8/dist-packages:/code/SuperBuild/install/bin/opensfm" \
-    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib"
+    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib" \
+    PDAL_DRIVER_PATH="/code/SuperBuild/install/bin"
 
 WORKDIR /code
 

--- a/portable.Dockerfile
+++ b/portable.Dockerfile
@@ -29,7 +29,8 @@ FROM ubuntu:21.04
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/lib/python3.9/dist-packages:/code/SuperBuild/install/lib/python3.8/dist-packages:/code/SuperBuild/install/bin/opensfm" \
-    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib"
+    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib" \
+    PDAL_DRIVER_PATH="/code/SuperBuild/install/bin"
 
 WORKDIR /code
 


### PR DESCRIPTION
*Should* fix https://community.opendronemap.org/t/webodm-docker-filesystem-error-cannot-make-canonical-path-please-help/14202/7

Haven't tested because no reproduction steps have been provided in the reports, but it's the only place where canonical paths are being created.

Should be caused by https://github.com/PDAL/PDAL/blob/a00819d42cfd1ecd7ab85c6d77ec277fa278aac9/pdal/PluginDirectory.cpp#L62 and so setting this env variable should fix the problem.