### PR TITLE
Better support for AeroVironment Quantix

### DIFF
--- a/SuperBuild/cmake/External-OpenSfM.cmake
+++ b/SuperBuild/cmake/External-OpenSfM.cmake
@@ -25,7 +25,7 @@ ExternalProject_Add(${_proj_name}
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
   GIT_REPOSITORY    https://github.com/OpenDroneMap/OpenSfM/
-  GIT_TAG           303
+  GIT_TAG           304
   #--Update/Patch step----------
   UPDATE_COMMAND    git submodule update --init --recursive
   #--Configure step-------------

--- a/opendm/multispectral.py
+++ b/opendm/multispectral.py
@@ -421,6 +421,18 @@ def compute_homography(image_filename, align_image_filename):
 def find_ecc_homography(image_gray, align_image_gray, number_of_iterations=1000, termination_eps=1e-8, start_eps=1e-4):
     pyramid_levels = 0
     h,w = image_gray.shape
+    max_dim = max(h, w)
+
+    max_size = 1280
+
+    if max_dim > max_size:
+        if max_dim == w:
+            f = max_size / w
+        else:
+            f = max_size / h
+        image_gray = cv2.resize(image_gray, None, fx=f, fy=f, interpolation=cv2.INTER_AREA)
+        h,w = image_gray.shape
+
     min_dim = min(h, w)
 
     while min_dim > 300:
@@ -434,10 +446,10 @@ def find_ecc_homography(image_gray, align_image_gray, number_of_iterations=1000,
         align_image_gray = to_8bit(align_image_gray)
         image_gray = to_8bit(image_gray)
 
-        fx = align_image_gray.shape[1]/image_gray.shape[1]
-        fy = align_image_gray.shape[0]/image_gray.shape[0]
+        fx = image_gray.shape[1]/align_image_gray.shape[1]
+        fy = image_gray.shape[0]/align_image_gray.shape[0]
 
-        image_gray = cv2.resize(image_gray, None, 
+        align_image_gray = cv2.resize(align_image_gray, None, 
                         fx=fx, 
                         fy=fy,
                         interpolation=(cv2.INTER_AREA if (fx < 1.0 and fy < 1.0) else cv2.INTER_LANCZOS4))

--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -459,6 +459,21 @@ class ODM_Photo:
                 # self.set_attr_from_xmp_tag('bandwidth', xtags, [
                 #     'Camera:WavelengthFWHM'
                 # ], float)
+        
+        # Special case band handling for AeroVironment Quantix images
+        # for some reason, they don't store band information in EXIFs
+        if self.camera_make.lower() == 'aerovironment' and \
+            self.camera_model.lower() == 'quantix':
+            matches = re.match("IMG_(\d+)_(\w+)\.\w+", self.filename, re.IGNORECASE)
+            if matches:
+                band_aliases = {
+                    'GRN': 'Green',
+                    'NIR': 'Nir',
+                    'RED': 'Red',
+                    'RGB': 'RedGreenBlue',
+                }
+                self.capture_uuid = matches.group(1)
+                self.band_name = band_aliases.get(matches.group(2), matches.group(2))
 
         # Sanitize band name since we use it in folder paths
         self.band_name = re.sub('[^A-Za-z0-9]+', '', self.band_name)

--- a/stages/run_opensfm.py
+++ b/stages/run_opensfm.py
@@ -104,9 +104,9 @@ class ODMOpenSfMStage(types.ODM_Stage):
                 image = func(shot_id, image)
             return image
 
-        def resize_thermal_images(shot_id, image):
+        def resize_secondary_images(shot_id, image):
             photo = reconstruction.get_photo(shot_id)
-            if photo.is_thermal():
+            if photo.band_name != primary_band_name:
                 return thermal.resize_to_match(image, largest_photo)
             else:
                 return image
@@ -138,8 +138,8 @@ class ODMOpenSfMStage(types.ODM_Stage):
                 return image
 
         if reconstruction.multi_camera:
-            largest_photo = find_largest_photo(photos)
-            undistort_pipeline.append(resize_thermal_images)
+            largest_photo = find_largest_photo([p for p in photos if p.band_name == primary_band_name])
+            undistort_pipeline.append(resize_secondary_images)
 
         if args.radiometric_calibration != "none":
             undistort_pipeline.append(radiometric_calibrate)


### PR DESCRIPTION
This PR improves support for AeroVironment Quantix drones. It's a bit hackish because band information does not seem to be available in EXIF meta (unless test images from https://community.opendronemap.org/t/quantix-mapper-multispectral-data/6706 got postprocessed, but doesn't seem like it), so we set the band name from the filename.

This drone has two sensors, a RGB camera and GRN camera, of different image resolutions, which are physically offset. https://www.avinc.com/images/uploads/product_docs/Quantix_Mapper_Datasheet_07222021.pdf

The current image alignment method might be able to get some results, but I would expect alignment issues. Investigation into camera rigs might be required here for mixing/matching the images from these two sensors.

I would recommend to process the images from sensors separately if alignment issues arise. Also, when processing from the multispectral sensor camera, I find that setting `--primary-band nir --sfm-algorithm planar --skip-band-alignment --fast-orthophoto` is a must, as the Green and Red bands seem to have a very weak signal. Perhaps this was just an issue with the test dataset. OpenMVS also kept crashing for some reason (thus `--fast-orthophoto`).

In short, I think this sensor might still require more work, but this should at least give users a chance to process some data and start experimenting.