### PR TITLE
EXIF capture_uuid for Parrot Sequoia

### DIFF
--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -350,6 +350,7 @@ class ODM_Photo:
                         '@drone-dji:CaptureUUID', # DJI
                         'MicaSense:CaptureId', # MicaSense Altum
                         '@Camera:ImageUniqueID', # sentera 6x
+                        '@Camera:CaptureUUID', # Parrot Sequoia
                     ])
 
                     self.set_attr_from_xmp_tag('gain', xtags, [


### PR DESCRIPTION
A simple change to "photo.py".
Added EXIF TAG for "Capture UUID" of Parrot Sequoia camera.
   (   @Camera:CaptureUUID   )
