### PR TITLE
Feature/admin64bit

### DIFF
--- a/innosetup.iss
+++ b/innosetup.iss
@@ -29,6 +29,7 @@ OutputBaseFilename=ODM_Setup_{#MyAppVersion}
 Compression=lzma
 SolidCompression=yes
 ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64
 SignTool=signtool
 PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=commandline

--- a/innosetup.iss
+++ b/innosetup.iss
@@ -31,6 +31,7 @@ SolidCompression=yes
 ArchitecturesAllowed=x64
 SignTool=signtool
 PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=commandline
 UsePreviousAppDir=no
 ;SetupIconFile=setup.ico
 


### PR DESCRIPTION
As discussed in [this topic](https://community.opendronemap.org/t/install-for-all-users-native-windows/14805/4) I made two modifications in the innosetup configuration file:
- Install program as a 64bit program because it is one. (Currently it appears under the 32bit programs install on the 64bit computer in the registry)
- All the program to be install for all users with elevated privileged if launched in command line with `/ALLUSERS` flag