### PR TITLE
fix outdated docs for angles in geo file

### DIFF
--- a/opendm/config.py
+++ b/opendm/config.py
@@ -485,11 +485,11 @@ def config(argv=None, parser=None):
                         action=StoreValue,
                         default=None,
                         help=('Path to the image geolocation file containing the camera center coordinates used for georeferencing. '
-                              'If you don''t have values for omega/phi/kappa you can set them to 0. '
+                              'If you don\'t have values for yaw/pitch/roll you can set them to 0. '
                               'The file needs to '
                               'use the following format: \n'
                               'EPSG:<code> or <+proj definition>\n'
-                              'image_name geo_x geo_y geo_z [omega (degrees)] [phi (degrees)] [kappa (degrees)] [horz accuracy (meters)] [vert accuracy (meters)]\n'
+                              'image_name geo_x geo_y geo_z [yaw (degrees)] [pitch (degrees)] [roll (degrees)] [horz accuracy (meters)] [vert accuracy (meters)]\n'
                               'Default: %(default)s'))
     
     parser.add_argument('--align',


### PR DESCRIPTION
According to the [question](https://community.opendronemap.org/t/geolocation-files-versus-exif-and-omega-phi-kappa-versus-pitch-roll-yaw/9905/2), [\[issue 1473\]](https://github.com/OpenDroneMap/ODM/issues/1473), [\[pr 1476\]](https://github.com/OpenDroneMap/ODM/pull/1476) and the following code, the `omega`, `phi`, `kappa` should be replaced to `yaw`, `pitch`, `roll`.

https://github.com/OpenDroneMap/ODM/blob/92cab06a5140730ce166fc22ea18aebbc9bc6093/opendm/geo.py#L39-L43
