### PR TITLE
Do not merge partial non-georeferenced reconstructions

### DIFF
--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -49,11 +49,12 @@ class OSFMContext:
         else:
             log.ODM_WARNING('Found a valid OpenSfM tracks file in: %s' % tracks_file)
 
-    def reconstruct(self, rolling_shutter_correct=False, rerun=False):
+    def reconstruct(self, rolling_shutter_correct=False, merge_partial=False, rerun=False):
         reconstruction_file = os.path.join(self.opensfm_project_path, 'reconstruction.json')
         if not io.file_exists(reconstruction_file) or rerun:
             self.run('reconstruct')
-            self.check_merge_partial_reconstructions()
+            if merge_partial:
+                self.check_merge_partial_reconstructions()
         else:
             log.ODM_WARNING('Found a valid OpenSfM reconstruction file in: %s' % reconstruction_file)
 
@@ -76,7 +77,7 @@ class OSFMContext:
 
                 self.match_features(True)
                 self.create_tracks(True)
-                self.reconstruct(rolling_shutter_correct=False, rerun=True)
+                self.reconstruct(rolling_shutter_correct=False, merge_partial=merge_partial, rerun=True)
 
                 self.touch(rs_file)
             else:

--- a/opendm/remote.py
+++ b/opendm/remote.py
@@ -448,7 +448,7 @@ class ReconstructionTask(Task):
         log.ODM_INFO("==================================")
         octx.feature_matching(self.params['rerun'])
         octx.create_tracks(self.params['rerun'])
-        octx.reconstruct(self.params['rolling_shutter'], self.params['rerun'])
+        octx.reconstruct(self.params['rolling_shutter'], True, self.params['rerun'])
     
     def process_remote(self, done):
         octx = OSFMContext(self.path("opensfm"))

--- a/stages/run_opensfm.py
+++ b/stages/run_opensfm.py
@@ -35,7 +35,7 @@ class ODMOpenSfMStage(types.ODM_Stage):
         octx.feature_matching(self.rerun())
         self.update_progress(30)
         octx.create_tracks(self.rerun())
-        octx.reconstruct(args.rolling_shutter, self.rerun())
+        octx.reconstruct(args.rolling_shutter, reconstruction.is_georeferenced(), self.rerun())
         octx.extract_cameras(tree.path("cameras.json"), self.rerun())
         self.update_progress(70)
 

--- a/stages/splitmerge.py
+++ b/stages/splitmerge.py
@@ -132,7 +132,7 @@ class ODMSplitStage(types.ODM_Stage):
                         log.ODM_INFO("Reconstructing %s" % sp)
                         local_sp_octx = OSFMContext(sp)
                         local_sp_octx.create_tracks(self.rerun())
-                        local_sp_octx.reconstruct(args.rolling_shutter, self.rerun())
+                        local_sp_octx.reconstruct(args.rolling_shutter, True, self.rerun())
                 else:
                     lre = LocalRemoteExecutor(args.sm_cluster, args.rolling_shutter, self.rerun())
                     lre.set_projects([os.path.abspath(os.path.join(p, "..")) for p in submodel_paths])


### PR DESCRIPTION
It makes no sense to attempt to merge partial reconstructions if there's no geographical reference, as parial reconstructions will be placed on separate coordinate systems. Better to just to keep the main reconstruction.
