### PR TITLE
Remove laspy

### DIFF
--- a/opendm/dem/commands.py
+++ b/opendm/dem/commands.py
@@ -49,13 +49,11 @@ def classify(lasFile, scalar, slope, threshold, window):
 def rectify(lasFile, reclassify_threshold=5, min_area=750, min_points=500):
     start = datetime.now()
 
-    pcFile = lasFile
-
     try:
 
         log.ODM_INFO("Rectifying {} using with [reclassify threshold: {}, min area: {}, min points: {}]".format(lasFile, reclassify_threshold, min_area, min_points))
         run_rectification(
-            input=pcFile, output=pcFile, \
+            input=lasFile, output=lasFile, \
             reclassify_plan='median', reclassify_threshold=reclassify_threshold, \
             extend_plan='surrounding', extend_grid_distance=5, \
             min_area=min_area, min_points=min_points)

--- a/opendm/dem/commands.py
+++ b/opendm/dem/commands.py
@@ -102,13 +102,13 @@ def create_dem(input_point_cloud, dem_type, output_type='max', radiuses=['0.56']
             w, h = (RES_FLOOR, int(math.ceil(ext_height / ext_width * RES_FLOOR)))
         else:
             w, h = (int(math.ceil(ext_width / ext_height * RES_FLOOR)), RES_FLOOR)
-
+        
         floor_ratio = prev_w / float(w)
         resolution *= floor_ratio
         radiuses = [str(float(r) * floor_ratio) for r in radiuses]
 
         log.ODM_WARNING("Really low resolution DEM requested %s will set floor at %s pixels. Resolution changed to %s. The scale of this reconstruction might be off." % ((prev_w, prev_h), RES_FLOOR, resolution))
-
+        
     final_dem_pixels = w * h
 
     num_splits = int(max(1, math.ceil(math.log(math.ceil(final_dem_pixels / float(max_tile_size * max_tile_size)))/math.log(2))))
@@ -144,7 +144,7 @@ def create_dem(input_point_cloud, dem_type, output_type='max', radiuses=['0.56']
                         'minx': minx,
                         'maxx': maxx,
                         'miny': miny,
-                        'maxy': maxy
+                        'maxy': maxy 
                     },
                     'filename': filename
                 })
@@ -157,7 +157,7 @@ def create_dem(input_point_cloud, dem_type, output_type='max', radiuses=['0.56']
 
     def process_tile(q):
         log.ODM_INFO("Generating %s (%s, radius: %s, resolution: %s)" % (q['filename'], output_type, q['radius'], resolution))
-
+        
         d = pdal.json_gdal_base(q['filename'], output_type, q['radius'], resolution, q['bounds'])
 
         if dem_type == 'dtm':
@@ -175,7 +175,7 @@ def create_dem(input_point_cloud, dem_type, output_type='max', radiuses=['0.56']
     output_path = os.path.abspath(os.path.join(outdir, output_file))
 
     # Verify tile results
-    for t in tiles:
+    for t in tiles: 
         if not os.path.exists(t['filename']):
             raise Exception("Error creating %s, %s failed to be created" % (output_file, t['filename']))
 
@@ -225,14 +225,14 @@ def create_dem(input_point_cloud, dem_type, output_type='max', radiuses=['0.56']
             '"{geotiff_tmp}" "{geotiff_small}"'.format(**kwargs))
 
         # Fill scaled
-        gdal_fillnodata(['.',
-                        '-co', 'NUM_THREADS=%s' % kwargs['threads'],
+        gdal_fillnodata(['.', 
+                        '-co', 'NUM_THREADS=%s' % kwargs['threads'], 
                         '-co', 'BIGTIFF=IF_SAFER',
                         '--config', 'GDAL_CACHE_MAX', str(kwargs['max_memory']) + '%',
                         '-b', '1',
                         '-of', 'GTiff',
                         kwargs['geotiff_small'], kwargs['geotiff_small_filled']])
-
+        
         # Merge filled scaled DEM with unfilled DEM using bilinear interpolation
         run('gdalbuildvrt -resolution highest -r bilinear "%s" "%s" "%s"' % (merged_vrt_path, geotiff_small_filled_path, geotiff_tmp_path))
         run('gdal_translate '
@@ -258,11 +258,11 @@ def create_dem(input_point_cloud, dem_type, output_type='max', radiuses=['0.56']
         os.replace(geotiff_path, output_path)
 
     if os.path.exists(geotiff_tmp_path):
-        if not keep_unfilled_copy:
+        if not keep_unfilled_copy: 
             os.remove(geotiff_tmp_path)
         else:
             os.replace(geotiff_tmp_path, io.related_file_path(output_path, postfix=".unfilled"))
-
+    
     for cleanup_file in [tiles_vrt_path, tiles_file_list, merged_vrt_path, geotiff_small_path, geotiff_small_filled_path]:
         if os.path.exists(cleanup_file): os.remove(cleanup_file)
     for t in tiles:
@@ -295,7 +295,7 @@ def compute_euclidean_map(geotiff_path, output_path, overwrite=False):
                 log.ODM_WARNING("Cannot compute euclidean distance file: %s" % output_path)
         else:
             log.ODM_WARNING("Cannot compute euclidean map, gdal_proximity is missing")
-
+            
     else:
         log.ODM_INFO("Found a euclidean distance map: %s" % output_path)
         return output_path

--- a/opendm/dem/commands.py
+++ b/opendm/dem/commands.py
@@ -46,7 +46,7 @@ def classify(lasFile, scalar, slope, threshold, window):
     log.ODM_INFO('Created %s in %s' % (lasFile, datetime.now() - start))
     return lasFile
 
-def rectify(lasFile, debug=False, reclassify_threshold=5, min_area=750, min_points=500):
+def rectify(lasFile, reclassify_threshold=5, min_area=750, min_points=500):
     start = datetime.now()
 
     pcFile = lasFile
@@ -55,7 +55,7 @@ def rectify(lasFile, debug=False, reclassify_threshold=5, min_area=750, min_poin
 
         log.ODM_INFO("Rectifying {} using with [reclassify threshold: {}, min area: {}, min points: {}]".format(lasFile, reclassify_threshold, min_area, min_points))
         run_rectification(
-            input=pcFile, output=pcFile, debug=debug, \
+            input=pcFile, output=pcFile, \
             reclassify_plan='median', reclassify_threshold=reclassify_threshold, \
             extend_plan='surrounding', extend_grid_distance=5, \
             min_area=min_area, min_points=min_points)

--- a/opendm/dem/commands.py
+++ b/opendm/dem/commands.py
@@ -73,7 +73,7 @@ def create_dem(input_point_cloud, dem_type, output_type='max', radiuses=['0.56']
                 decimation=None, keep_unfilled_copy=False,
                 apply_smoothing=True):
     """ Create DEM from multiple radii, and optionally gapfill """
-
+    
     global error
     error = None
 
@@ -97,7 +97,7 @@ def create_dem(input_point_cloud, dem_type, output_type='max', radiuses=['0.56']
     RES_FLOOR = 64
     if w < RES_FLOOR and h < RES_FLOOR:
         prev_w, prev_h = w, h
-
+        
         if w >= h:
             w, h = (RES_FLOOR, int(math.ceil(ext_height / ext_width * RES_FLOOR)))
         else:

--- a/opendm/dem/ground_rectification/io/las_io.py
+++ b/opendm/dem/ground_rectification/io/las_io.py
@@ -1,5 +1,3 @@
-# TODO: Move to pylas when project migrates to python3
-
 import time
 import pdal
 import numpy as np
@@ -9,8 +7,6 @@ import pdb
 import json
 
 def read_cloud(point_cloud_path):
-
-    # Open point cloud and read its properties using pdal
     pipeline = pdal.Pipeline('[{"type":"readers.las","filename":"%s"}]' % point_cloud_path)
     pipeline.execute()
 
@@ -25,15 +21,8 @@ def read_cloud(point_cloud_path):
     green = arrays["Green"]
     blue = arrays["Blue"]
 
-    # Create PointCloud object
     cloud = PointCloud.with_dimensions(x, y, z, classification, red, green, blue)
 
-    # Print what is inside pipeline.metadata
-    #log.ODM_INFO("pipeline.metadata: %s" % str(pipeline.metadata))
-
-    log.ODM_INFO("OK")
-
-    # Return the result
     return pipeline.metadata["metadata"]["readers.las"], cloud
 
 
@@ -75,8 +64,6 @@ def write_cloud(metadata, point_cloud, output_point_cloud_path):
     arrays['Green'] = green.astype(np.uint8).ravel()
     arrays['Blue'] = blue.astype(np.uint8).ravel()
 
-    #log.ODM_INFO("Write extra dimensions: %s" % write_extra_dimensions)
-
     writer_pipeline = {
         "pipeline": [
             {
@@ -105,8 +92,6 @@ def write_cloud(metadata, point_cloud, output_point_cloud_path):
     safe_add_metadata(writer_pipeline, metadata, "file_source_id")
     safe_add_metadata(writer_pipeline, metadata, "global_encoding")
 
-    #pdb.set_trace()
-
     # The metadata object contains the VLRs as fields called "vlr_N" where N is the index of the VLR
     # We have to copy them over to the writer pipeline as a list of dictionaries in the "vlrs" field
     writer_pipeline["pipeline"][0]["vlrs"] = []
@@ -126,9 +111,5 @@ def write_cloud(metadata, point_cloud, output_point_cloud_path):
         else:
             break
 
-    #log.ODM_INFO("writer_pipeline: %s" % str(writer_pipeline))
-
     pipeline = pdal.Pipeline(json.dumps(writer_pipeline), arrays=[arrays])
-
-    # Write point cloud with PDAL
     pipeline.execute()

--- a/opendm/dem/ground_rectification/io/las_io.py
+++ b/opendm/dem/ground_rectification/io/las_io.py
@@ -14,38 +14,92 @@ def read_cloud(point_cloud_path):
     pipeline = pdal.Pipeline('[{"type":"readers.las","filename":"%s"}]' % point_cloud_path)
     pipeline.execute()
 
-    metadata = pipeline.metadata
-    arrays = pipeline.arrays
+    arrays = pipeline.arrays[0]
+
+    # print arrays shape
+    log.ODM_INFO(str(arrays.shape))
+    log.ODM_INFO(str(arrays.dtype))
+    log.ODM_INFO(str(arrays))
+    log.ODM_INFO(str(arrays[0]))
 
     # Extract point coordinates, classification, and RGB values
-    x = arrays[0]["X"]
-    y = arrays[0]["Y"]
-    z = arrays[0]["Z"]
-    classification = arrays[0]["Classification"].astype(np.uint8)
-    red = arrays[0]["Red"]
-    green = arrays[0]["Green"]
-    blue = arrays[0]["Blue"]
+    x = arrays["X"]
+    y = arrays["Y"]
+    z = arrays["Z"]
+    classification = arrays["Classification"].astype(np.uint8)
+    red = arrays["Red"]
+    green = arrays["Green"]
+    blue = arrays["Blue"]
 
     # Create PointCloud object
     cloud = PointCloud.with_dimensions(x, y, z, classification, red, green, blue)
 
     # Return the result
-    return metadata, cloud
+    return pipeline.metadata, cloud
+
 
 def write_cloud(metadata, point_cloud, output_point_cloud_path, write_extra_dimensions=False):
 
-    # Create PDAL pipeline to write point cloud
-    pipeline = pdal.Pipeline('[{"type": "writers.las","filename": "%s","compression": "laszip","extra_dims": %s}]' %
-                             (output_point_cloud_path, str(write_extra_dimensions).lower()))
-
     # Adapt points to scale and offset
-    [x, y] = np.hsplit(point_cloud.xy, 2)
+    x, y = np.hsplit(point_cloud.xy, 2)
     z = point_cloud.z
 
     # Set color
-    [red, green, blue] = np.hsplit(point_cloud.rgb, 3)
+    red, green, blue = np.hsplit(point_cloud.rgb, 3)
+
     # Set classification
     classification = point_cloud.classification.astype(np.uint8)
 
+    # Print array dimensions
+    x = x.ravel()
+    y = y.ravel()
+    classification = classification.ravel()
+    red = red.astype(np.uint8).ravel()
+    green = green.astype(np.uint8).ravel()
+    blue = blue.astype(np.uint8).ravel()
+
+    arrays = np.zeros(len(x),
+                      dtype=[('X', '<f8'),
+                             ('Y', '<f8'),
+                             ('Z', '<f8'),
+                             ('Intensity', '<u2'),
+                             ('ReturnNumber', 'u1'),
+                             ('NumberOfReturns', 'u1'),
+                             ('ScanDirectionFlag', 'u1'),
+                             ('EdgeOfFlightLine', 'u1'),
+                             ('Classification', 'u1'),
+                             ('ScanAngleRank', '<f4'),
+                             ('UserData', 'u1'),
+                             ('PointSourceId', '<u2'),
+                             ('GpsTime', '<f8'),
+                             ('Red', '<u2'),
+                             ('Green', '<u2'),
+                             ('Blue', '<u2')])
+    arrays['X'] = x
+    arrays['Y'] = y
+    arrays['Z'] = z
+    arrays['Classification'] = classification
+    arrays['Red'] = red
+    arrays['Green'] = green
+    arrays['Blue'] = blue
+
+    #test_data = np.array(
+    #        [(x, y, z) for x, y, z in zip(x_vals, y_vals, z_vals)],
+    #        dtype=[("X", float), ("Y", float), ("Z", float)],
+    #    )
+
+    log.ODM_INFO("arrays: %s" % str(arrays.shape))
+    log.ODM_INFO("arrays: %s" % arrays)
+    log.ODM_INFO("arrays: %s" % arrays[0])
+    log.ODM_INFO("Write extra dimensions: %s" % write_extra_dimensions)
+
+    # Create PDAL pipeline to write point cloud
+    #pipeline = pdal.Pipeline('[{"type": "writers.las","filename": "%s","compression": "laszip", "extra_dims": %s}]' %
+    #                         (output_point_cloud_path, str(write_extra_dimensions).lower()), arrays=[arrays])
+
+    pipeline = pdal.Pipeline('[{"type": "writers.las","filename": "%s","compression": "laszip"}]' % output_point_cloud_path, arrays=[arrays])
+
+    log.ODM_INFO("Dest path: %s" % output_point_cloud_path)
+
     # Write point cloud with PDAL
-    pipeline.execute(np.column_stack((x, y, z, red, green, blue, classification)))
+    pipeline.execute()

--- a/opendm/dem/ground_rectification/io/las_io.py
+++ b/opendm/dem/ground_rectification/io/las_io.py
@@ -12,72 +12,40 @@ def read_cloud(point_cloud_path):
 
     # Open point cloud and read its properties using pdal
     pipeline = pdal.Pipeline('[{"type":"readers.las","filename":"%s"}]' % point_cloud_path)
-    cnt = pipeline.execute()
+    pipeline.execute()
 
-    log.ODM_INFO("pdal arrays: %s" % pipeline.arrays)
+    metadata = pipeline.metadata
+    arrays = pipeline.arrays
 
-    dimensions = pipeline.schema['schema']['dimensions']
-    #log.ODM_INFO("Type: %s" % type(pipeline.schema))
-    log.ODM_INFO("Dimensions: %s" % dimensions)
+    # Extract point coordinates, classification, and RGB values
+    x = arrays[0]["X"]
+    y = arrays[0]["Y"]
+    z = arrays[0]["Z"]
+    classification = arrays[0]["Classification"].astype(np.uint8)
+    red = arrays[0]["Red"]
+    green = arrays[0]["Green"]
+    blue = arrays[0]["Blue"]
 
-    # The x column index is the index of the object with the name 'X'
-    x_index = next((index for (index, d) in enumerate(dimensions) if d['name'] == 'X'), None)
-    y_index = next((index for (index, d) in enumerate(dimensions) if d['name'] == 'Y'), None)
-    z_index = next((index for (index, d) in enumerate(dimensions) if d['name'] == 'Z'), None)
-    classification_index = next((index for (index, d) in enumerate(dimensions) if d['name'] == 'Classification'), None)
-    red_index = next((index for (index, d) in enumerate(dimensions) if d['name'] == 'Red'), None)
-    green_index = next((index for (index, d) in enumerate(dimensions) if d['name'] == 'Green'), None)
-    blue_index = next((index for (index, d) in enumerate(dimensions) if d['name'] == 'Blue'), None)
-
-    # Log indices
-    log.ODM_INFO("x_index: %s" % x_index)
-    log.ODM_INFO("y_index: %s" % y_index)
-    log.ODM_INFO("z_index: %s" % z_index)
-    log.ODM_INFO("classification_index: %s" % classification_index)
-    log.ODM_INFO("red_index: %s" % red_index)
-    log.ODM_INFO("green_index: %s" % green_index)
-    log.ODM_INFO("blue_index: %s" % blue_index)
-
-    pts = pipeline.arrays[0]
-    log.ODM_INFO("pts: %s" % pts)
-
-    x = (pt[x_index] for pt in pts)
-    y = (pt[y_index] for pt in pts)
-    z = (pt[z_index] for pt in pts)
-    classification = (pt[classification_index] for pt in pts)
-    red = (pt[red_index] for pt in pts)
-    green = (pt[green_index] for pt in pts)
-    blue = (pt[blue_index] for pt in pts)
-
+    # Create PointCloud object
     cloud = PointCloud.with_dimensions(x, y, z, classification, red, green, blue)
 
     # Return the result
-    return pipeline.metadata, cloud
+    return metadata, cloud
 
-def write_cloud(header, point_cloud, output_point_cloud_path, write_extra_dimensions=False):
-    # Open output file
-    output_las_file = laspy.LasData(header)
+def write_cloud(metadata, point_cloud, output_point_cloud_path, write_extra_dimensions=False):
 
-    if write_extra_dimensions:
-        extra_dims = [laspy.ExtraBytesParams(name=name, type=dimension.get_las_type(), description="Dimension added by Ground Extend") for name, dimension in point_cloud.extra_dimensions_metadata.items()]
-        output_las_file.add_extra_dims(extra_dims)
-        # Assign dimension values
-        for dimension_name, values in point_cloud.extra_dimensions.items():
-            setattr(output_las_file, dimension_name, values)
+    # Create PDAL pipeline to write point cloud
+    pipeline = pdal.Pipeline('[{"type": "writers.las","filename": "%s","compression": "laszip","extra_dims": %s}]' %
+                             (output_point_cloud_path, str(write_extra_dimensions).lower()))
 
     # Adapt points to scale and offset
     [x, y] = np.hsplit(point_cloud.xy, 2)
-    output_las_file.x = x.ravel()
-    output_las_file.y = y.ravel()
-    output_las_file.z = point_cloud.z
+    z = point_cloud.z
 
     # Set color
     [red, green, blue] = np.hsplit(point_cloud.rgb, 3)
-    output_las_file.red = red.ravel()
-    output_las_file.green = green.ravel()
-    output_las_file.blue = blue.ravel()
-
     # Set classification
-    output_las_file.classification = point_cloud.classification.astype(np.uint8)
+    classification = point_cloud.classification.astype(np.uint8)
 
-    output_las_file.write(output_point_cloud_path)
+    # Write point cloud with PDAL
+    pipeline.execute(np.column_stack((x, y, z, red, green, blue, classification)))

--- a/opendm/dem/ground_rectification/io/las_io.py
+++ b/opendm/dem/ground_rectification/io/las_io.py
@@ -43,8 +43,7 @@ def safe_add_metadata(pipeline, metadata, key, sourcekey=None):
         pipeline["pipeline"][0][key] = metadata[k]
 
 
-def write_cloud(metadata, point_cloud, output_point_cloud_path, write_extra_dimensions=False):
-
+def write_cloud(metadata, point_cloud, output_point_cloud_path):
 
     # Adapt points to scale and offset
     x, y = np.hsplit(point_cloud.xy, 2)
@@ -83,7 +82,8 @@ def write_cloud(metadata, point_cloud, output_point_cloud_path, write_extra_dime
             {
                 "type": "writers.las",
                 "filename": output_point_cloud_path,
-                "compression": "laszip"
+                "compression": "laszip",
+                "extra_dims": "all"
             }
         ]
     }
@@ -106,9 +106,6 @@ def write_cloud(metadata, point_cloud, output_point_cloud_path, write_extra_dime
     safe_add_metadata(writer_pipeline, metadata, "global_encoding")
 
     #pdb.set_trace()
-
-    if write_extra_dimensions:
-        writer_pipeline["pipeline"][0]["extra_dims"] = "all"
 
     # The metadata object contains the VLRs as fields called "vlr_N" where N is the index of the VLR
     # We have to copy them over to the writer pipeline as a list of dictionaries in the "vlrs" field

--- a/opendm/dem/ground_rectification/io/las_io.py
+++ b/opendm/dem/ground_rectification/io/las_io.py
@@ -16,12 +16,6 @@ def read_cloud(point_cloud_path):
 
     arrays = pipeline.arrays[0]
 
-    # print arrays shape
-    log.ODM_INFO(str(arrays.shape))
-    log.ODM_INFO(str(arrays.dtype))
-    log.ODM_INFO(str(arrays))
-    log.ODM_INFO(str(arrays[0]))
-
     # Extract point coordinates, classification, and RGB values
     x = arrays["X"]
     y = arrays["Y"]

--- a/opendm/dem/ground_rectification/rectify.py
+++ b/opendm/dem/ground_rectification/rectify.py
@@ -23,7 +23,7 @@ def run_rectification(**kwargs):
     if 'extend_plan' in kwargs and kwargs['extend_plan'] is not None:
         point_cloud = extend_cloud(point_cloud, kwargs['extend_plan'], kwargs['extend_grid_distance'], kwargs['min_points'], kwargs['min_area'])
 
-    write_cloud(header, point_cloud, kwargs['output'], kwargs['debug'])
+    write_cloud(header, point_cloud, kwargs['output'])
 
 def reclassify_cloud(point_cloud, plan, threshold, min_points, min_area):
     # Get only ground

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ Fiona==1.8.17 ; sys_platform == 'linux'
 Fiona==1.9.1 ; sys_platform == 'darwin'
 https://github.com/OpenDroneMap/windows-deps/raw/main/Fiona-1.8.19-cp38-cp38-win_amd64.whl ; sys_platform == 'win32'
 joblib==1.1.0
-laspy[lazrs]==2.3.0 ; sys_platform == 'linux' or sys_platform == 'win32'
-laspy==2.3.0 ; sys_platform == 'darwin'
 lxml==4.6.1
 matplotlib==3.3.3
 networkx==2.5

--- a/stages/odm_dem.py
+++ b/stages/odm_dem.py
@@ -72,7 +72,7 @@ class ODMDEMStage(types.ODM_Stage):
         self.update_progress(progress)
 
         if args.pc_rectify:
-            commands.rectify(dem_input, False)
+            commands.rectify(dem_input)
 
         # Do we need to process anything here?
         if (args.dsm or args.dtm) and pc_model_found:


### PR DESCRIPTION
Closes #1600 

Tested on Linux. The code has been modified to use PDAL instead of Laspy, which has resulted in the elimination of one dependency. However, I was unable to test the code path where the `write_extra_dimensions` parameter is set to `True`. @pierotofy, could you kindly provide a test case for this scenario? Thank you!

Please note that the auto-formatter has made some edits to the `commands.py` file by removing duplicate spaces. Please disregard these changes. The only modification I made was to the `rectify` method, where I removed the laspy workaround for macOS.
