### PR TITLE
Fix strange python launcher error when folder has spaces

### DIFF
--- a/.github/workflows/test-build-prs.yaml
+++ b/.github/workflows/test-build-prs.yaml
@@ -66,12 +66,6 @@ jobs:
       uses: jwlawson/actions-setup-cmake@v1.13
       with:
         cmake-version: '3.24.x'
-    - name: Extract code signing cert
-      id: code_sign
-      uses: timheuer/base64-to-file@v1
-      with:
-        fileName: 'comodo.pfx'
-        encodedString: ${{ secrets.CODE_SIGNING_CERT }}
     - name: Install venv
       run: |
         python -m pip install virtualenv
@@ -84,10 +78,8 @@ jobs:
         rmdir SuperBuild\build /s /q
       shell: cmd
     - name: Create setup
-      env: 
-        CODE_SIGN_CERT_PATH: ${{ steps.code_sign.outputs.filePath }}
       run: |
-        python configure.py dist --code-sign-cert-path $env:CODE_SIGN_CERT_PATH
+        python configure.py dist
     - name: Upload Setup File
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/test-build-prs.yaml
+++ b/.github/workflows/test-build-prs.yaml
@@ -58,17 +58,38 @@ jobs:
       with:
         python-version: '3.8.1'
         architecture: 'x64'
+    - uses: Jimver/cuda-toolkit@v0.2.4
+      id: cuda-toolkit
+      with:
+        cuda: '11.4.0'
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@v1.13
       with:
         cmake-version: '3.24.x'
-    - name: Setup Visual C++
-      uses: ilammy/msvc-dev-cmd@v1
+    - name: Extract code signing cert
+      id: code_sign
+      uses: timheuer/base64-to-file@v1
       with:
-        arch: x64
+        fileName: 'comodo.pfx'
+        encodedString: ${{ secrets.CODE_SIGNING_CERT }}
     - name: Install venv
       run: |
         python -m pip install virtualenv
     - name: Build sources
       run: |
         python configure.py build
+    - name: Free up space
+      run: |
+        rmdir SuperBuild\download /s /q
+        rmdir SuperBuild\build /s /q
+      shell: cmd
+    - name: Create setup
+      env: 
+        CODE_SIGN_CERT_PATH: ${{ steps.code_sign.outputs.filePath }}
+      run: |
+        python configure.py dist --code-sign-cert-path $env:CODE_SIGN_CERT_PATH
+    - name: Upload Setup File
+      uses: actions/upload-artifact@v2
+      with:
+        name: Setup
+        path: dist\*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ settings.yaml
 __pycache__
 *.snap
 storage/
+
+
+vcpkg/
+venv/
+python38/
+dist/
+innosetup/

--- a/configure.py
+++ b/configure.py
@@ -193,7 +193,7 @@ def dist():
             z.extractall("innosetup")
 
     # Run
-    cs_flags = '"/Ssigntool=%s"' % signtool_path
+    cs_flags = '/DSKIP_SIGN=1'
     if args.code_sign_cert_path:
         cs_flags = '"/Ssigntool=%s sign /f %s /fd SHA1 /t http://timestamp.sectigo.com $f"' % (signtool_path, args.code_sign_cert_path)
     run("innosetup\\iscc /Qp " + cs_flags  + " \"innosetup.iss\"")

--- a/configure.py
+++ b/configure.py
@@ -193,7 +193,7 @@ def dist():
             z.extractall("innosetup")
 
     # Run
-    cs_flags = ""
+    cs_flags = '"/Ssigntool=%s"' % signtool_path
     if args.code_sign_cert_path:
         cs_flags = '"/Ssigntool=%s sign /f %s /fd SHA1 /t http://timestamp.sectigo.com $f"' % (signtool_path, args.code_sign_cert_path)
     run("innosetup\\iscc /Qp " + cs_flags  + " \"innosetup.iss\"")

--- a/innosetup.iss
+++ b/innosetup.iss
@@ -47,7 +47,7 @@ Source: "stages\*"; DestDir: "{app}\stages"; Excludes: "__pycache__"; Flags: ign
 Source: "SuperBuild\install\bin\*"; DestDir: "{app}\SuperBuild\install\bin"; Excludes: "__pycache__"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "SuperBuild\install\lib\python3.8\*"; DestDir: "{app}\SuperBuild\install\lib\python3.8"; Excludes: "__pycache__"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "venv\*"; DestDir: "{app}\venv"; Excludes: "__pycache__,pyvenv.cfg"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "python38\*"; DestDir: "{app}\python38"; Excludes: "__pycache__"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "python38\*"; DestDir: "{app}\venv\Scripts"; Excludes: "__pycache__"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "console.bat"; DestDir: "{app}"; Flags: ignoreversion
 Source: "VERSION"; DestDir: "{app}"; Flags: ignoreversion
 Source: "LICENSE"; DestDir: "{app}"; Flags: ignoreversion
@@ -70,70 +70,6 @@ Filename: "{tmp}\vc_redist.x64.exe"; StatusMsg: "Installing Visual C++ Redistrib
 Filename: "{app}\console.bat"; Description: {cm:LaunchProgram,ODM Console}; Flags: nowait postinstall skipifsilent
 
 [Code]
-
-function GetShortPath(const LongPath: string): string;
-var
-  ResultCode: Integer;
-  TmpFileName: string;
-  ExecStdout: AnsiString;
-  Parameters: string;
-begin
-
-  // Create LongPath folder
-  if not ForceDirectories(LongPath) then begin
-    Result := LongPath;
-    Exit;
-  end;
-
-  TmpFileName := ExpandConstant('{tmp}') + '\short_result.txt';
-  Parameters := '-Command "(New-Object -ComObject Scripting.FileSystemObject).GetFolder(''' + LongPath + ''').ShortPath | Out-File -FilePath ''' + TmpFileName + ''' -Encoding ASCII"';
-
-  // Execute the PowerShell command and save the output to the TmpFileName
-  if Exec('powershell.exe', Parameters, '', 0, ewWaitUntilTerminated, ResultCode) then
-  begin
-    // Read the output from the TmpFileName
-    if LoadStringFromFile(TmpFileName, ExecStdout) then begin
-      Result := Trim(ExecStdout);
-      end
-    else begin
-      Result := LongPath;
-    end;
-
-    DeleteFile(TmpFileName);
-    // Delete the folder
-    if not RemoveDir(LongPath) then begin
-      Result := LongPath;
-      Exit;
-    end;
-
-  end
-  else
-  begin
-    Result := LongPath;
-  end;
-end;
-
-
-function NextButtonClick(CurPageID: Integer): Boolean;
-var
-  Dir: string;
-begin
-  if CurPageID = wpSelectDir then
-  begin
-    // Get the selected directory
-    Dir := WizardForm.DirEdit.Text;
-
-    // Check if the path contains spaces
-    if Pos(' ', Dir) > 0 then
-    begin
-      // Get the short path name
-      Dir := GetShortPath(Dir);
-      // Set the selected directory to the short path name
-      WizardForm.DirEdit.Text := Dir;
-    end;
-  end;
-  Result := True;
-end;
 
 function VC2019RedistNeedsInstall: Boolean;
 var

--- a/innosetup.iss
+++ b/innosetup.iss
@@ -30,7 +30,9 @@ Compression=lzma
 SolidCompression=yes
 ArchitecturesAllowed=x64
 ArchitecturesInstallIn64BitMode=x64
+#ifndef SKIP_SIGN
 SignTool=signtool
+#endif
 PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=commandline
 UsePreviousAppDir=no

--- a/innosetup.iss
+++ b/innosetup.iss
@@ -70,18 +70,83 @@ Filename: "{tmp}\vc_redist.x64.exe"; StatusMsg: "Installing Visual C++ Redistrib
 Filename: "{app}\console.bat"; Description: {cm:LaunchProgram,ODM Console}; Flags: nowait postinstall skipifsilent
 
 [Code]
+
+function GetShortPath(const LongPath: string): string;
+var
+  ResultCode: Integer;
+  TmpFileName: string;
+  ExecStdout: AnsiString;
+  Parameters: string;
+begin
+
+  // Create LongPath folder
+  if not ForceDirectories(LongPath) then begin
+    Result := LongPath;
+    Exit;
+  end;
+
+  TmpFileName := ExpandConstant('{tmp}') + '\short_result.txt';
+  Parameters := '-Command "(New-Object -ComObject Scripting.FileSystemObject).GetFolder(''' + LongPath + ''').ShortPath | Out-File -FilePath ''' + TmpFileName + ''' -Encoding ASCII"';
+
+  // Execute the PowerShell command and save the output to the TmpFileName
+  if Exec('powershell.exe', Parameters, '', 0, ewWaitUntilTerminated, ResultCode) then
+  begin
+    // Read the output from the TmpFileName
+    if LoadStringFromFile(TmpFileName, ExecStdout) then begin
+      Result := Trim(ExecStdout);
+      end
+    else begin
+      Result := LongPath;
+    end;
+
+    DeleteFile(TmpFileName);
+    // Delete the folder
+    if not RemoveDir(LongPath) then begin
+      Result := LongPath;
+      Exit;
+    end;
+
+  end
+  else
+  begin
+    Result := LongPath;
+  end;
+end;
+
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+var
+  Dir: string;
+begin
+  if CurPageID = wpSelectDir then
+  begin
+    // Get the selected directory
+    Dir := WizardForm.DirEdit.Text;
+
+    // Check if the path contains spaces
+    if Pos(' ', Dir) > 0 then
+    begin
+      // Get the short path name
+      Dir := GetShortPath(Dir);
+      // Set the selected directory to the short path name
+      WizardForm.DirEdit.Text := Dir;
+    end;
+  end;
+  Result := True;
+end;
+
 function VC2019RedistNeedsInstall: Boolean;
-var 
+var
   Version: String;
 begin
   if RegQueryStringValue(HKEY_LOCAL_MACHINE,
        'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64', 'Version', Version) then
   begin
-    // Is the installed version at least 14.14 ? 
+    // Is the installed version at least 14.14 ?
     Log('VC Redist Version check : found ' + Version);
     Result := (CompareStr(Version, 'v14.14.26429.03')<0);
   end
-  else 
+  else
   begin
     // Not even an old version installed
     Result := True;

--- a/win32env.bat
+++ b/win32env.bat
@@ -24,7 +24,7 @@ set PYTHONPATH=%VIRTUAL_ENV%
 set PYENVCFG=%VIRTUAL_ENV%\pyvenv.cfg
 
 rem Hot-patching pyvenv.cfg
-echo home = %ODMBASE%\python38> "%PYENVCFG%"
+echo home = %ODMBASE%venv\Scripts> "%PYENVCFG%"
 echo include-system-site-packages = false>> "%PYENVCFG%"
 
 rem Hot-patching cv2 extension configs


### PR DESCRIPTION
This PR fixes the behavior of innosetup to use the windows short path when it contains spaces.
The issue seems to be related to https://github.com/pypa/setuptools/issues/216 and several others. I tested the same exact setup with newer python versions and they work fine. Unfortunately we are stuck with python 3.8 due to breaking changes in newer versions.

Bonus: added `vcpkg`, `venv`, `python38`, `dist` and `innosetup` folders to gitignore.

Closes #1569 