### PR TITLE
add opensfm arg: matching_order_neighbors

### DIFF
--- a/opendm/config.py
+++ b/opendm/config.py
@@ -153,6 +153,13 @@ def config(argv=None, parser=None):
                         default=0,
                         type=int,
                         help='Perform image matching with the nearest images based on GPS exif data. Set to 0 to match by triangulation. Default: %(default)s')
+    
+    parser.add_argument('--matcher-order-neighbors',
+                            metavar='<positive integer>',
+                            action=StoreValue,
+                            default=0,
+                            type=int,
+                            help='Perform image matching with the nearest images based on image order. Set to 0 to disable. Default: %(default)s')
 
     parser.add_argument('--use-fixed-camera-params',
                         action=StoreTrue,

--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -246,6 +246,9 @@ class OSFMContext:
                 "triangulation_type: ROBUST",
                 "retriangulation_ratio: 2",
             ]
+            
+            if args.matcher_order_neighbors > 0:
+                config.append(f"matching_order_neighbors: {args.matcher_order_neighbors}")
 
             if args.camera_lens != 'auto':
                 config.append("camera_projection_type: %s" % args.camera_lens.upper())


### PR DESCRIPTION
Added "--matching_order_neighbors" argument for opensfm to allow faster feature matching if images are in sequence eg. extracted from video. 