### PR TITLE
Use windowed read/write in median_smoothing

### DIFF
--- a/opendm/dem/commands.py
+++ b/opendm/dem/commands.py
@@ -338,7 +338,6 @@ def median_smoothing(geotiff_path, output_path, smoothing_iterations=1, window_s
 
 
     log.ODM_INFO('Completed smoothing to create %s in %s' % (output_path, datetime.now() - start))
-    exit(42)
     return output_path
 
 


### PR DESCRIPTION
See the issue description in this forum comment:
https://community.opendronemap.org/t/post-processing-after-odm/16314/16?u=adrien-anton-ludwig

TL;DR:
Median smoothing used windowing to go through the array but read it entirely in RAM. Now the full potential of windowing is exploited to read/write by chunks.

## Tests

I tested it on a very small dataset of 18 images on an external HDD.
Here are the results:

```python
>>> median_smoothing(input, output, smoothing_iterations=1000, num_workers=16)
# Before
 [INFO] Completed smoothing to create /datasets/windowed_io/odm_meshing/tmp/mesh_dsm.tif in 0:00:30.055436
# After
 [INFO] Completed smoothing to create /datasets/windowed_io/odm_meshing/tmp/mesh_dsm.tif in 0:00:28.892439
```

I also used `cksum` to compare the resulting files, which were exactly the same.

---

Do not hesitate if you have ideas for further testing. :wink: