### PR TITLE
Fix RFLY EXIF parsing

### DIFF
--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -630,6 +630,8 @@ class ODM_Photo:
     def int_values(self, tag):
         if isinstance(tag.values, list):
             return [int(v) for v in tag.values]
+        elif isinstance(tag.values, str) and tag.values == '':
+            return [0]
         else:
             return [int(tag.values)]
 


### PR DESCRIPTION
Fixes [#1362](https://github.com/OpenDroneMap/WebODM/issues/1362) which is caused by malformed GPSAltitudeRef tags
