### PR TITLE
Run GPU build on self-hosted runner

### DIFF
--- a/.github/workflows/publish-docker-gpu.yaml
+++ b/.github/workflows/publish-docker-gpu.yaml
@@ -9,14 +9,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    timeout-minutes: 2880
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Set Swap Space
-      uses: pierotofy/set-swap-space@master
-      with:
-        swap-size-gb: 12
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx


### PR DESCRIPTION
I suspect GitHub has changed the amount of disk space we get on the free runners, which means the GPU build keeps failing due to lack of disk space.

Changing the config to use our runner instead.
