### PR TITLE
Pin Eigen 3.4

### DIFF
--- a/SuperBuild/cmake/External-OpenMVS.cmake
+++ b/SuperBuild/cmake/External-OpenMVS.cmake
@@ -14,7 +14,7 @@ externalproject_add(vcg
 
 externalproject_add(eigen34
     GIT_REPOSITORY  https://gitlab.com/libeigen/eigen.git
-    GIT_TAG         3.4
+    GIT_TAG         7176ae16238ded7fb5ed30a7f5215825b3abd134
     UPDATE_COMMAND  ""
     SOURCE_DIR      ${SB_SOURCE_DIR}/eigen34
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
Should fix the build, broken due to this commit. https://gitlab.com/libeigen/eigen/-/commit/08ca9841545a1d65e63b3a8bc600ec07b6e81275

```
2023-11-05T17:49:08.6942912Z #13 24186.5 /code/SuperBuild/src/eigen34/Eigen/src/Core/arch/NEON/PacketMath.h:81:1: error: version control conflict marker in file
2023-11-05T17:49:08.6945672Z #13 24186.5    81 | <<<<<<< HEAD
2023-11-05T17:49:08.6946771Z #13 24186.5       | ^~~~~~~
```