### PR TITLE
GLTF - obj2glb - Set extensionsUsed in all cases to be consistent with the GLTF standard

### DIFF
--- a/opendm/gltf.py
+++ b/opendm/gltf.py
@@ -279,9 +279,10 @@ def obj2glb(input_obj, output_glb, rtc=(None, None), draco_compression=True, _in
     )
 
     gltf.extensionsRequired = ['KHR_materials_unlit']
+    gltf.extensionsUsed = ['KHR_materials_unlit']
 
     if rtc != (None, None) and len(rtc) >= 2:
-        gltf.extensionsUsed = ['CESIUM_RTC', 'KHR_materials_unlit']
+        gltf.extensionsUsed.append('CESIUM_RTC')
         gltf.extensions = {
             'CESIUM_RTC': {
                 'center': [float(rtc[0]), float(rtc[1]), 0.0]


### PR DESCRIPTION
As the GLTF Definition [states](https://github.com/KhronosGroup/glTF/blob/main/extensions/README.md#extension-mechanics)

> All extensions used in a model are listed as strings in the top-level extensionsUsed array.

So `extensionsUsed` should be set in all cases. With this change `extensionsUsed` is set even if `rtc` is `(None, None)` (which is the default).

In our use case we didn't had georeferences so `rtc` was not set and the created `glb` file couldn't be loaded with the three.js GLTFLoader because `extensionsUsed` was not set.