### PR TITLE
Add Mavic 3 rolling shutter, not enterprise version

### DIFF
--- a/opendm/rollingshutter.py
+++ b/opendm/rollingshutter.py
@@ -19,7 +19,7 @@ RS_DATABASE = {
     
     'dji fc220': 64, # DJI Mavic Pro (Platinum)
     'hasselblad l1d-20c': lambda p: 47 if p.get_capture_megapixels() < 17 else 56, # DJI Mavic 2 Pro (at 16:10 => 16.8MP 47ms, at 3:2 => 19.9MP 56ms. 4:3 has 17.7MP with same image height as 3:2 which can be concluded as same sensor readout)
-    'hasselblad l2d-20c': 16.6,
+    'hasselblad l2d-20c': 16.6, # DJI Mavic 3 (not enterprise version)
 
     'dji fc3582': lambda p: 26 if p.get_capture_megapixels() < 48 else 60, # DJI Mini 3 pro (at 48MP readout is 60ms, at 12MP it's 26ms) 
 

--- a/opendm/rollingshutter.py
+++ b/opendm/rollingshutter.py
@@ -19,6 +19,7 @@ RS_DATABASE = {
     
     'dji fc220': 64, # DJI Mavic Pro (Platinum)
     'hasselblad l1d-20c': lambda p: 47 if p.get_capture_megapixels() < 17 else 56, # DJI Mavic 2 Pro (at 16:10 => 16.8MP 47ms, at 3:2 => 19.9MP 56ms. 4:3 has 17.7MP with same image height as 3:2 which can be concluded as same sensor readout)
+    'hasselblad l2d-20c': 16.6,
 
     'dji fc3582': lambda p: 26 if p.get_capture_megapixels() < 48 else 60, # DJI Mini 3 pro (at 48MP readout is 60ms, at 12MP it's 26ms) 
 


### PR DESCRIPTION
Add Mavic 3 to database as waypoint are now allowed in DJI Mini 4 Pro, Air 3, and Mavic 3

Source: https://www.pix-pro.com/blog/post/dji-mavic-3-rolling-shutter