### PR TITLE
Fix PoissonRecon failed with n threads log message

### DIFF
--- a/opendm/mesh.py
+++ b/opendm/mesh.py
@@ -187,7 +187,7 @@ def screened_poisson_reconstruction(inPointCloud, outMesh, depth = 8, samples = 
             if threads < 1:
                 break
             else:
-                log.ODM_WARNING("PoissonRecon failed with %s threads, let's retry with %s..." % (threads, threads // 2))
+                log.ODM_WARNING("PoissonRecon failed with %s threads, let's retry with %s..." % (threads * 2, threads))
 
 
     # Cleanup and reduce vertex count if necessary


### PR DESCRIPTION
The message was reporting failure with `n` threads and retrying with `n // 2`, however a few lines up `threads` was already set to `n // 2` representing the next thread count to try.

You'll see currently the log finishing with

```
[WARNING] PoissonRecon failed with 1 threads, let's retry with 0...
```

which demonstrates the issues.