### PR TITLE
Add black level support for certain DJI drones

### DIFF
--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -413,6 +413,17 @@ class ODM_Photo:
                         self.set_attr_from_xmp_tag('speed_z', xtags, [
                             '@drone-dji:FlightZSpeed',
                         ], float)
+
+                    # DJI MS
+                    if self.black_level is None and 'Camera:BlackCurrent' in xtags:
+                        self.set_attr_from_xmp_tag('black_level', xtags, [
+                            'Camera:BlackCurrent'
+                        ], str)
+                    if '@drone-dji:ExposureTime' in xtags:
+                        self.set_attr_from_xmp_tag('exposure_time', xtags, [
+                            '@drone-dji:ExposureTime'
+                        ], float)
+                        self.exposure_time /= 1e6 # is in microseconds
                     
                     # Account for over-estimation
                     if self.gps_xy_stddev is not None:


### PR DESCRIPTION
Adds support for reading the `BlackCurrent` (black level) tag in DJI drones (e.g. M3M).

I also noticed that in absence of a radiometric calibration coefficient (from Micasense), the multiplication skews the reflectance values. I can't quite remember why we had such a fallback multiplication, but I can't find any reference in the updated Micasense codebase, so I think it's correct and safe to remove.

Might solve https://community.opendronemap.org/t/need-help-with-dji-m3m-ortophoto-generation/20893 (issue 2).

