### PR TITLE
Add a WARNING when a geo file is specified but the file does not exist

### DIFF
--- a/stages/dataset.py
+++ b/stages/dataset.py
@@ -187,6 +187,9 @@ class ODMLoadDatasetStage(types.ODM_Stage):
                             p.compute_opk()
                             updated += 1
                     log.ODM_INFO("Updated %s image positions" % updated)
+                # Warn if a file path is specified but it does not exist
+                elif tree.odm_geo_file is not None and not os.path.isfile(tree.odm_geo_file):
+                    log.ODM_WARNING("Image geolocation file %s does not exist" % tree.odm_geo_file) 
 
                 # GPSDOP override if we have GPS accuracy information (such as RTK)
                 if 'gps_accuracy_is_set' in args:


### PR DESCRIPTION
Hi, 

I was trying to use a geo.txt file option to override my input image geolocation metadata. I ran a case with and without the `--geo <path>` option to compare and was surprised when the results were the same. When searching for the cause, I realised I had a typo in my geo.txt file path. However, when reviewing the logs, I noticed that an `ODM_INFO` message is printed to the logs when the file is correctly found but no message is printed when a path is given but no file is found. Hence this pull request: I suggest adding an `ODM_WARNING` message to the logs to help users debug such a case. 

Thanks for all your work on this excellent open source project! 