### PR TITLE
Cannot initialize CUDA even if nvidia-smi detected

### DIFF
--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -38,6 +38,7 @@ COPY --from=builder /code /code
 # Copy the Python libraries installed via pip from the builder
 COPY --from=builder /usr/local /usr/local
 #COPY --from=builder /usr/lib/x86_64-linux-gnu/libavcodec.so.58 /usr/lib/x86_64-linux-gnu/libavcodec.so.58
+RUN dpkg --remove cuda-compat-11-2
 RUN apt-get update -y \
  && apt-get install -y ffmpeg libtbb2
 # Install shared libraries that we depend on via APT, but *not*


### PR DESCRIPTION
CUDA can't be properly initialized if cuda-compat on host and docker mismatches. Removing cuda-compat-11-2 package fixes the issue

Issue discussion:
https://community.opendronemap.org/t/opendronemap-nodeodm-gpu-nvidia-smi-detected-cannot-initialize-cuda/21124
log:
```
[INFO] nvidia-smi detected
[INFO] Using CPU for feature extraction: Cannot initialize CUDA
```