### PR TITLE
Add missing log import

### DIFF
--- a/opendm/gltf.py
+++ b/opendm/gltf.py
@@ -6,6 +6,7 @@ import numpy as np
 import pygltflib
 from opendm import system
 from opendm import io
+from opendm import log
 
 warnings.filterwarnings("ignore", category=rasterio.errors.NotGeoreferencedWarning)
 


### PR DESCRIPTION
The `log.ODM_WARNING` call on gltf.py fails because of a missing import statement.