### PR TITLE
Try to fix georeferencing accuracy 

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -25,9 +25,9 @@ check_version(){
 }
 
 if [[ $2 =~ ^[0-9]+$ ]] ; then
-    processes=$2
+    processes=2
 else
-    processes=$(nproc)
+    processes=2
 fi
 
 ensure_prereqs() {

--- a/configure.sh
+++ b/configure.sh
@@ -25,9 +25,9 @@ check_version(){
 }
 
 if [[ $2 =~ ^[0-9]+$ ]] ; then
-    processes=2
+    processes=$2
 else
-    processes=2
+    processes=$(nproc)
 fi
 
 ensure_prereqs() {

--- a/opendm/georef.py
+++ b/opendm/georef.py
@@ -2,31 +2,7 @@ import numpy as np
 from numpy import ndarray
 from typing import Tuple
 from pyproj import Proj
-import argparse
 from opensfm.geo import TopocentricConverter
-
-def parse_pdal_args(pdal_args: dict) -> argparse.Namespace:
-    def validate_arg(name: str, data_type: type):
-        if name not in pdal_args:
-            raise ValueError(f"PDAL arguments should contain {name}.")
-        try:
-             data_type(pdal_args[name])
-        except ValueError:
-            raise ValueError(f"PDAL argument {name} should be of type {data_type}.")
-        return data_type(pdal_args[name])
-    return argparse.Namespace(
-        reflat=validate_arg('reflat', float),
-        reflon=validate_arg('reflon', float),
-        refalt=validate_arg('refalt', float),
-        x_offset=validate_arg('x_offset', float),
-        y_offset=validate_arg('y_offset', float),
-        a_srs=validate_arg('a_srs', str)
-    )
-
-def topocentric_to_georef_pdal(ins, outs):
-    args = parse_pdal_args(ins)
-    outs['X'], outs['Y'], outs['Z'] = topocentric_to_georef(args.reflat, args.reflon, args.refalt, args.a_srs, ins['X'], ins['Y'], ins['Z'], args.x_offset, args.y_offset)
-    return True
 
 def topocentric_to_georef(
         reflat: float, 
@@ -44,6 +20,37 @@ def topocentric_to_georef(
     lat, lon, alt = reference.to_lla(x, y, z)
     easting, northing = projection(lon, lat)
     return easting - x_offset, northing - y_offset, alt
+
+
+class TopocentricToProj:
+    def __init__(self, reflat:float, reflon:float, refalt:float, a_srs:str):
+        self.reference = TopocentricConverter(reflat, reflon, refalt)
+        self.projection = Proj(a_srs)
+        
+    def convert_array(self, arr:ndarray, offset_x:float=0, offset_y:float=0):
+        x, y, z = arr['X'], arr['Y'], arr['Z']
+        easting, northing, alt = self.convert_points(x, y, z, offset_x, offset_y)
+        arr['X'] = easting
+        arr['Y'] = northing
+        arr['Z'] = alt
+        return arr
+    
+    def convert_points(self, x:ndarray, y:ndarray, z:ndarray, offset_x:float=0, offset_y:float=0):
+        lat, lon, alt = self.reference.to_lla(x, y, z)
+        easting, northing = self.projection(lon, lat)
+        return easting - offset_x, northing - offset_y, alt
+        
+    def convert_obj(self, input_obj:str, output_obj:str, offset_x:float=0, offset_y:float=0):
+        with open(input_obj, 'r') as fin:
+            with open(output_obj, 'w') as fout:
+                lines = fin.readlines()
+                for line in lines:
+                    if line.startswith("v "):
+                        v = np.fromstring(line.strip()[2:] + " 1",  sep=' ', dtype=float)
+                        vt = self.convert_points(v[0], v[1], v[2], offset_x, offset_y)
+                        fout.write("v " + " ".join(map(str, list(vt))) + '\n')
+                    else:
+                        fout.write(line)
 
 
     

--- a/opendm/georef.py
+++ b/opendm/georef.py
@@ -1,0 +1,49 @@
+import numpy as np
+from numpy import ndarray
+from typing import Tuple
+from pyproj import Proj
+import argparse
+from opensfm.geo import TopocentricConverter
+
+def parse_pdal_args(pdal_args: dict) -> argparse.Namespace:
+    def validate_arg(name: str, data_type: type):
+        if name not in pdal_args:
+            raise ValueError(f"PDAL arguments should contain {name}.")
+        try:
+             data_type(pdal_args[name])
+        except ValueError:
+            raise ValueError(f"PDAL argument {name} should be of type {data_type}.")
+        return data_type(pdal_args[name])
+    return argparse.Namespace(
+        reflat=validate_arg('reflat', float),
+        reflon=validate_arg('reflon', float),
+        refalt=validate_arg('refalt', float),
+        x_offset=validate_arg('x_offset', float),
+        y_offset=validate_arg('y_offset', float),
+        a_srs=validate_arg('a_srs', str)
+    )
+
+def topocentric_to_georef_pdal(ins, outs):
+    args = parse_pdal_args(ins)
+    outs['X'], outs['Y'], outs['Z'] = topocentric_to_georef(args.reflat, args.reflon, args.refalt, args.a_srs, ins['X'], ins['Y'], ins['Z'], args.x_offset, args.y_offset)
+    return True
+
+def topocentric_to_georef(
+        reflat: float, 
+        reflon: float, 
+        refalt: float, 
+        a_srs: str, 
+        x: ndarray, 
+        y: ndarray, 
+        z: ndarray,
+        x_offset: float = 0,
+        y_offset: float = 0,
+    ) -> Tuple[ndarray, ndarray, ndarray]:
+    reference = TopocentricConverter(reflat, reflon, refalt)
+    projection = Proj(a_srs)
+    lat, lon, alt = reference.to_lla(x, y, z)
+    easting, northing = projection(lon, lat)
+    return easting - x_offset, northing - y_offset, alt
+
+
+    

--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -631,7 +631,7 @@ class OSFMContext:
     
     def reference(self):
         ds = DataSet(self.opensfm_project_path)
-        return ds.load_reference_lla()
+        return ds.load_reference()
 
     def name(self):
         return os.path.basename(os.path.abspath(self.path("..")))    

--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -629,9 +629,12 @@ class OSFMContext:
 
         return result
     
+    def reference(self):
+        ds = DataSet(self.opensfm_project_path)
+        return ds.load_reference_lla()
 
     def name(self):
-        return os.path.basename(os.path.abspath(self.path("..")))
+        return os.path.basename(os.path.abspath(self.path("..")))    
 
 def get_submodel_argv(args, submodels_path = None, submodel_name = None):
     """

--- a/opendm/types.py
+++ b/opendm/types.py
@@ -361,16 +361,20 @@ class ODM_Tree(object):
         self.openmvs_model = os.path.join(self.openmvs, 'scene_dense_dense_filtered.ply')
 
         # filter points
+        self.filtered_point_cloud_topo = os.path.join(self.odm_filterpoints, "point_cloud_topocentric.ply")
         self.filtered_point_cloud = os.path.join(self.odm_filterpoints, "point_cloud.ply")
         self.filtered_point_cloud_stats = os.path.join(self.odm_filterpoints, "point_cloud_stats.json")
 
         # odm_meshing
+        self.odm_mesh_topo = os.path.join(self.odm_meshing, 'odm_mesh_topocentric.ply')
         self.odm_mesh = os.path.join(self.odm_meshing, 'odm_mesh.ply')
         self.odm_meshing_log = os.path.join(self.odm_meshing, 'odm_meshing_log.txt')
+        self.odm_25dmesh_topo = os.path.join(self.odm_meshing, 'odm_25dmesh_topocentric.ply')
         self.odm_25dmesh = os.path.join(self.odm_meshing, 'odm_25dmesh.ply')
         self.odm_25dmeshing_log = os.path.join(self.odm_meshing, 'odm_25dmeshing_log.txt')
 
         # texturing
+        self.odm_textured_model_obj_topo = os.path.join(self.odm_texturing, 'odm_textured_model_topocentric.obj')
         self.odm_textured_model_obj = 'odm_textured_model_geo.obj'
         self.odm_textured_model_glb = 'odm_textured_model_geo.glb'
 

--- a/opendm/types.py
+++ b/opendm/types.py
@@ -374,7 +374,7 @@ class ODM_Tree(object):
         self.odm_25dmeshing_log = os.path.join(self.odm_meshing, 'odm_25dmeshing_log.txt')
 
         # texturing
-        self.odm_textured_model_obj_topo = os.path.join(self.odm_texturing, 'odm_textured_model_topocentric.obj')
+        self.odm_textured_model_obj_topo = 'odm_textured_model_topocentric.obj'
         self.odm_textured_model_obj = 'odm_textured_model_geo.obj'
         self.odm_textured_model_glb = 'odm_textured_model_geo.glb'
 

--- a/stages/mvstex.py
+++ b/stages/mvstex.py
@@ -33,7 +33,7 @@ class ODMMvsTexStage(types.ODM_Stage):
             if not args.skip_3dmodel and (primary or args.use_3dmesh):
                 nonloc.runs += [{
                     'out_dir': os.path.join(tree.odm_texturing, subdir),
-                    'model': tree.odm_mesh,
+                    'model': tree.odm_mesh_topo,
                     'nadir': False,
                     'primary': primary,
                     'nvm_file': nvm_file,
@@ -43,7 +43,7 @@ class ODMMvsTexStage(types.ODM_Stage):
             if not args.use_3dmesh:
                 nonloc.runs += [{
                     'out_dir': os.path.join(tree.odm_25dtexturing, subdir),
-                    'model': tree.odm_25dmesh,
+                    'model': tree.odm_25dmesh_topo,
                     'nadir': True,
                     'primary': primary,
                     'nvm_file': nvm_file,
@@ -69,7 +69,7 @@ class ODMMvsTexStage(types.ODM_Stage):
             if not io.dir_exists(r['out_dir']):
                 system.mkdir_p(r['out_dir'])
 
-            odm_textured_model_obj = os.path.join(r['out_dir'], tree.odm_textured_model_obj)
+            odm_textured_model_obj = os.path.join(r['out_dir'], tree.odm_textured_model_obj_topo)
             unaligned_obj = io.related_file_path(odm_textured_model_obj, postfix="_unaligned")
 
             if not io.file_exists(odm_textured_model_obj) or self.rerun():
@@ -147,7 +147,7 @@ class ODMMvsTexStage(types.ODM_Stage):
                             shutil.rmtree(packed_dir)
                         
                         try:
-                            obj_pack(os.path.join(r['out_dir'], tree.odm_textured_model_obj), packed_dir, _info=log.ODM_INFO)
+                            obj_pack(os.path.join(r['out_dir'], tree.odm_textured_model_obj_topo), packed_dir, _info=log.ODM_INFO)
                             
                             # Move packed/* into texturing folder
                             system.delete_files(r['out_dir'], (".vec", ))

--- a/stages/mvstex.py
+++ b/stages/mvstex.py
@@ -71,7 +71,6 @@ class ODMMvsTexStage(types.ODM_Stage):
 
             odm_textured_model_obj = os.path.join(r['out_dir'], tree.odm_textured_model_obj_topo)
             unaligned_obj = io.related_file_path(odm_textured_model_obj, postfix="_unaligned")
-
             if not io.file_exists(odm_textured_model_obj) or self.rerun():
                 log.ODM_INFO('Writing MVS Textured file in: %s'
                               % odm_textured_model_obj)
@@ -94,7 +93,7 @@ class ODMMvsTexStage(types.ODM_Stage):
                 # mvstex definitions
                 kwargs = {
                     'bin': context.mvstex_path,
-                    'out_dir': os.path.join(r['out_dir'], "odm_textured_model_geo"),
+                    'out_dir': os.path.join(r['out_dir'], tree.odm_textured_model_obj_topo.split('.obj')[0]),
                     'model': r['model'],
                     'dataTerm': 'gmi',
                     'outlierRemovalType': 'gauss_clamping',

--- a/stages/mvstex.py
+++ b/stages/mvstex.py
@@ -90,10 +90,12 @@ class ODMMvsTexStage(types.ODM_Stage):
                 if (r['nadir']):
                     nadir = '--nadir_mode'
 
+                
                 # mvstex definitions
+                # mtl and texture files would be the same between topo and proj geomodel, so create with the final name
                 kwargs = {
                     'bin': context.mvstex_path,
-                    'out_dir': os.path.join(r['out_dir'], tree.odm_textured_model_obj_topo.split('.obj')[0]),
+                    'out_dir': os.path.join(r['out_dir'], 'odm_textured_model_geo'),
                     'model': r['model'],
                     'dataTerm': 'gmi',
                     'outlierRemovalType': 'gauss_clamping',
@@ -124,6 +126,9 @@ class ODMMvsTexStage(types.ODM_Stage):
                         '{nadirMode} '
                         '{labelingFile} '
                         '{maxTextureSize} '.format(**kwargs))
+                
+                # update the obj file name to topo for further conversion
+                shutil.move(os.path.join(r['out_dir'], tree.odm_textured_model_obj), odm_textured_model_obj)
 
                 if r['primary'] and (not r['nadir'] or args.skip_3dmodel):
                     # GlTF?

--- a/stages/odm_filterpoints.py
+++ b/stages/odm_filterpoints.py
@@ -19,7 +19,7 @@ class ODMFilterPoints(types.ODM_Stage):
         inputPointCloud = ""
         
         # check if reconstruction was done before
-        if not io.file_exists(tree.filtered_point_cloud) or self.rerun():
+        if not io.file_exists(tree.filtered_point_cloud_topo) or self.rerun():
             if args.fast_orthophoto:
                 inputPointCloud = os.path.join(tree.opensfm, 'reconstruction.ply')
             else:
@@ -49,14 +49,14 @@ class ODMFilterPoints(types.ODM_Stage):
                 else:
                     log.ODM_WARNING("Not a georeferenced reconstruction, will ignore --auto-boundary")
                     
-            point_cloud.filter(inputPointCloud, tree.filtered_point_cloud, tree.filtered_point_cloud_stats,
+            point_cloud.filter(inputPointCloud, tree.filtered_point_cloud_topo, tree.filtered_point_cloud_stats,
                                 standard_deviation=args.pc_filter, 
                                 sample_radius=args.pc_sample,
                                 boundary=boundary_offset(outputs.get('boundary'), reconstruction.get_proj_offset()),
                                 max_concurrency=args.max_concurrency)
             
             # Quick check
-            info = point_cloud.ply_info(tree.filtered_point_cloud)
+            info = point_cloud.ply_info(tree.filtered_point_cloud_topo)
             if info["vertex_count"] == 0:
                 extra_msg = ''
                 if 'boundary' in outputs:
@@ -64,7 +64,7 @@ class ODMFilterPoints(types.ODM_Stage):
                 raise system.ExitException("Uh oh! We ended up with an empty point cloud. This means that the reconstruction did not succeed. Have you followed best practices for data acquisition? See https://docs.opendronemap.org/flying/%s" % extra_msg)
         else:
             log.ODM_WARNING('Found a valid point cloud file in: %s' %
-                            tree.filtered_point_cloud)
+                            tree.filtered_point_cloud_topo)
         
         if args.optimize_disk_space and inputPointCloud:
             if os.path.isfile(inputPointCloud):

--- a/stages/odm_georeferencing.py
+++ b/stages/odm_georeferencing.py
@@ -133,7 +133,10 @@ class ODMGeoreferencingStage(types.ODM_Stage):
                     reconstruction.georef.utm_east_offset,
                     reconstruction.georef.utm_north_offset
                 )
-                pipeline = pdal.Writer.ply(tree.filtered_point_cloud).pipeline(arr)
+                pipeline = pdal.Writer.ply(
+                    filename = tree.filtered_point_cloud,
+                    storage_mode = "little endian",
+                ).pipeline(arr)
                 pipeline.execute()
             else:
                 shutil.copy(tree.filtered_point_cloud_topo, tree.filtered_point_cloud)

--- a/stages/odm_meshing.py
+++ b/stages/odm_meshing.py
@@ -19,11 +19,11 @@ class ODMeshingStage(types.ODM_Stage):
 
         # Create full 3D model unless --skip-3dmodel is set
         if not args.skip_3dmodel:
-          if not io.file_exists(tree.odm_mesh) or self.rerun():
-              log.ODM_INFO('Writing ODM Mesh file in: %s' % tree.odm_mesh)
+          if not io.file_exists(tree.odm_mesh_topo) or self.rerun():
+              log.ODM_INFO('Writing ODM Mesh file in: %s' % tree.odm_mesh_topo)
 
-              mesh.screened_poisson_reconstruction(tree.filtered_point_cloud,
-                tree.odm_mesh,
+              mesh.screened_poisson_reconstruction(tree.filtered_point_cloud_topo,
+                tree.odm_mesh_topo,
                 depth=self.params.get('oct_tree'),
                 samples=self.params.get('samples'),
                 maxVertexCount=self.params.get('max_vertex'),
@@ -31,16 +31,16 @@ class ODMeshingStage(types.ODM_Stage):
                 threads=max(1, self.params.get('max_concurrency') - 1)), # poissonrecon can get stuck on some machines if --threads == all cores
           else:
               log.ODM_WARNING('Found a valid ODM Mesh file in: %s' %
-                              tree.odm_mesh)
+                              tree.odm_mesh_topo)
         
         self.update_progress(50)
 
         # Always generate a 2.5D mesh
         # unless --use-3dmesh is set.
         if not args.use_3dmesh:
-          if not io.file_exists(tree.odm_25dmesh) or self.rerun():
+          if not io.file_exists(tree.odm_25dmesh_topo) or self.rerun():
 
-              log.ODM_INFO('Writing ODM 2.5D Mesh file in: %s' % tree.odm_25dmesh)
+              log.ODM_INFO('Writing ODM 2.5D Mesh file in: %s' % tree.odm_25dmesh_topo)
 
               multiplier = math.pi / 2.0
               radius_steps = commands.get_dem_radius_steps(tree.filtered_point_cloud_stats, 3, args.orthophoto_resolution, multiplier=multiplier)
@@ -51,7 +51,7 @@ class ODMeshingStage(types.ODM_Stage):
               if args.fast_orthophoto:
                   dsm_resolution *= 8.0
 
-              mesh.create_25dmesh(tree.filtered_point_cloud, tree.odm_25dmesh,
+              mesh.create_25dmesh(tree.filtered_point_cloud_topo, tree.odm_25dmesh_topo,
                     radius_steps,
                     dsm_resolution=dsm_resolution, 
                     depth=self.params.get('oct_tree'),
@@ -63,5 +63,5 @@ class ODMeshingStage(types.ODM_Stage):
                     max_tiles=None if reconstruction.has_geotagged_photos() else math.ceil(len(reconstruction.photos) / 2))
           else:
               log.ODM_WARNING('Found a valid ODM 2.5D Mesh file in: %s' %
-                              tree.odm_25dmesh)
+                              tree.odm_25dmesh_topo)
 

--- a/stages/run_opensfm.py
+++ b/stages/run_opensfm.py
@@ -69,13 +69,13 @@ class ODMOpenSfMStage(types.ODM_Stage):
         self.update_progress(75)
 
         # We now switch to a geographic CRS
-        if reconstruction.is_georeferenced() and (not io.file_exists(tree.opensfm_topocentric_reconstruction) or self.rerun()):
-            octx.run('export_geocoords --reconstruction --proj "%s" --offset-x %s --offset-y %s' % 
-                (reconstruction.georef.proj4(), reconstruction.georef.utm_east_offset, reconstruction.georef.utm_north_offset))
-            shutil.move(tree.opensfm_reconstruction, tree.opensfm_topocentric_reconstruction)
-            shutil.move(tree.opensfm_geocoords_reconstruction, tree.opensfm_reconstruction)
-        else:
-            log.ODM_WARNING("Will skip exporting %s" % tree.opensfm_geocoords_reconstruction)
+        # if reconstruction.is_georeferenced() and (not io.file_exists(tree.opensfm_topocentric_reconstruction) or self.rerun()):
+        #     octx.run('export_geocoords --reconstruction --proj "%s" --offset-x %s --offset-y %s' % 
+        #         (reconstruction.georef.proj4(), reconstruction.georef.utm_east_offset, reconstruction.georef.utm_north_offset))
+        #     shutil.move(tree.opensfm_reconstruction, tree.opensfm_topocentric_reconstruction)
+        #     shutil.move(tree.opensfm_geocoords_reconstruction, tree.opensfm_reconstruction)
+        # else:
+        #     log.ODM_WARNING("Will skip exporting %s" % tree.opensfm_geocoords_reconstruction)
         
         self.update_progress(80)
 


### PR DESCRIPTION
This issue was discussed earlier here https://community.opendronemap.org/t/model-accuracy-issues-related-to-geocoord-exports/13054/1

The horizontal error can get up to meters when the GCPs are a few kilometer away from the dataset center. The change would definitely slow down the processing speed a bit, but I think such big errors shouldn't be acceptable. My proposed fix is 
1. Skip exporting geocoord in opensfm stage, so the file generated will all be in topocentric coordinate system.
2. In the following stages, openmvs, filter_pointcloud, odm_meshing, odm_texturing will all generate assets in topocentric coordinate system, assets will include `_topocentric` in name. openmvs and odm_texturing do require the camera parameters remain unchanged to guarantee accuracy, so all these stages have to be kept in topocentric
3. In odm_georeferencing stage, convert all the topocentric assets that are needed in the final output to UTM coordinate system, the conversion should be done point by point instead of using a rigid affine transformation matrix. 
4. The orthophoto and dsm will be generated with assets in UTM coordinate system. 

The current implementation is done by using pdal-python to read and write the points, and use numpy to do bulk conversions. For obj file, I simply followed the implementation in the alignment method. For efficiency, if we can use newer version of PROJ lib, it supports topocentric conversion method, so we could define a proj pipeline and use pdal solely to do the conversion https://proj.org/en/stable/operations/conversions/topocentric.html#geocentric-to-topocentric-conversion. This should provide faster speed. 

Currently I implemented converting `odm_georeferenced_model.laz`, `point_cloud.ply` and `odm_textured_model_geo.obj`, I need to check 25dmeshing related files as I don't normally use it. Let me know if any other file should be included. 

You could find some error calculations numerically in the post above. Below is a comparison between orthophotos processed in two ways, the gcp is around 1km away from the dataset center

Rigid transfrom(current way)
![Screenshot from 2025-04-02 17-19-19](https://github.com/user-attachments/assets/400d2288-ccd4-4f59-85cf-5c8da02c8c6d)
![Screenshot from 2025-04-02 18-28-09](https://github.com/user-attachments/assets/b9256ffa-02cb-492e-be1f-495979e2f6e0)

Point to point transform(proposed fix)
![Screenshot from 2025-04-02 17-19-24](https://github.com/user-attachments/assets/bb6ee0ac-3780-484e-84b6-55accfc8de5d)
