### PR TITLE
Declare gdal_proximity to handle nullcheck

### DIFF
--- a/opendm/dem/commands.py
+++ b/opendm/dem/commands.py
@@ -20,6 +20,8 @@ from opendm import log
 from .ground_rectification.rectify import run_rectification
 from . import pdal
 
+gdal_proximity = None
+
 try:
     # GDAL >= 3.3
     from osgeo_utils.gdal_proximity import main as gdal_proximity


### PR DESCRIPTION
Fix for handling nullcheck on gdal_proximity.

Machine Details: 16x80
- Debian 5.10.223-1 (2024-08-10) x86_64 GNU/Linux
- NVIDIA T4 GPU: 16GB

Container Tested:
opendronemap/nodeodm:gpu

GDAL PIP INFO:
show GDAL
Name: GDAL
Version: 3.0.4
Summary: GDAL: Geospatial Data Abstraction Library
Home-page: http://www.gdal.org
Author: Howard Butler
Author-email: hobu.inc@gmail.com
License: MIT
Location: /usr/lib/python3/dist-packages
Requires: 
Required-by:


```
Traceback (most recent call last):
File "/code/run.py", line 65, in <module>
retcode = app.execute()
File "/code/stages/odm_app.py", line 118, in execute
raise e
File "/code/stages/odm_app.py", line 82, in execute
self.first_stage.run()
File "/code/opendm/types.py", line 470, in run
self.next_stage.run(outputs)
File "/code/opendm/types.py", line 470, in run
self.next_stage.run(outputs)
File "/code/opendm/types.py", line 470, in run
self.next_stage.run(outputs)
[Previous line repeated 5 more times]
File "/code/opendm/types.py", line 449, in run
self.process(self.args, outputs)
File "/code/stages/odm_dem.py", line 66, in process
commands.create_dem(
File "/code/opendm/dem/commands.py", line 187, in create_dem
compute_euclidean_map(tiles_vrt_path, emap_path, overwrite=True)
File "/code/opendm/dem/commands.py", line 213, in compute_euclidean_map
if gdal_proximity is not None:
NameError: name 'gdal_proximity' is not defined
```