### PR TITLE
Add DJI Mini 4 Pro (FC8482) rolling shutter readout times

### DIFF
--- a/opendm/rollingshutter.py
+++ b/opendm/rollingshutter.py
@@ -22,7 +22,13 @@ RS_DATABASE = {
     'hasselblad l2d-20c': 16.6, # DJI Mavic 3 (not enterprise version)
 
     'dji fc3582': lambda p: 26 if p.get_capture_megapixels() < 48 else 60, # DJI Mini 3 pro (at 48MP readout is 60ms, at 12MP it's 26ms) 
-
+    'dji fc8482': lambda p: (
+        16 if p.get_capture_megapixels() < 12 else  # 12MP 16:9 mode (actual 9.1MP)
+        21 if p.get_capture_megapixels() < 20 else  # 12MP 4:3 mode (actual 12.2MP)
+        43 if p.get_capture_megapixels() < 45 else  # 48MP 16:9 mode (actual 36.6MP)
+        58                                          # 48MP 4:3 mode (actual 48.8MP)
+    ), # DJI Mini 4 Pro (readout varies by resolution and aspect ratio, image heights all different)
+    
     'dji fc350': 30, # Inspire 1
     
     'dji mavic2-enterprise-advanced': 31, # DJI Mavic 2 Enterprise Advanced


### PR DESCRIPTION
I've measured the rolling shutter readout times for the DJI Mini 4 Pro with FC8482 sensor across each of the resolution and aspect ratio modes:

- 48MP 4:3 (8064×6048): 58ms
- 48MP 16:9 (8064×4536): 43ms
- 12MP 4:3 (4032×3024): 21ms
- 12MP 16:9 (4032×2268): 16ms

These measurements were taken using the LED blink test method at 2kHz frequency with fast shutter speeds as described in the RSCalibration repository. If there's somewhere I should upload full images with exif, let me know. 

Let me know if any changes recommended! First time contributing. Cheers

![12mp_43_21ms](https://github.com/user-attachments/assets/b64c75ba-57fc-4901-9493-8a2df2c519b4) ![12mp_169_16ms](https://github.com/user-attachments/assets/05caf3e6-d835-457c-aec9-de16ce56b7a6) ![48mp_43_58ms](https://github.com/user-attachments/assets/5e7119ed-11d3-4ab2-bec3-4867575568bd) ![48mp_169_43ms](https://github.com/user-attachments/assets/e0169f60-055b-425b-95a4-580786ee0a60)
