### PR TITLE
Allow the usage of a different output directory in winpostinstall.bat

### DIFF
--- a/winpostinstall.bat
+++ b/winpostinstall.bat
@@ -1,6 +1,7 @@
 set ODMBASE=%~dp0
 set VIRTUAL_ENV=%ODMBASE%venv
 IF "%~1"=="" (set WRITABLE_VIRTUAL_ENV=%VIRTUAL_ENV%) ELSE (set WRITABLE_VIRTUAL_ENV=%~1)
+mkdir "%WRITABLE_VIRTUAL_ENV%"
 
 rem Hot-patching pyvenv.cfg
 set PYENVCFG=%WRITABLE_VIRTUAL_ENV%\pyvenv.cfg
@@ -9,7 +10,9 @@ echo include-system-site-packages = false>> "%PYENVCFG%"
 
 rem Hot-patching cv2 extension configs
 set SBBIN=%ODMBASE%SuperBuild\install\bin
-echo BINARIES_PATHS = [r"%SBBIN%"] + BINARIES_PATHS> "%WRITABLE_VIRTUAL_ENV%\Lib\site-packages\cv2\config.py"
-echo PYTHON_EXTENSIONS_PATHS = [r'''%VIRTUAL_ENV%\lib\site-packages\cv2\python-3.8'''] + PYTHON_EXTENSIONS_PATHS> "%WRITABLE_VIRTUAL_ENV%\Lib\site-packages\cv2\config-3.8.py"
+set CV2=%WRITABLE_VIRTUAL_ENV%\Lib\site-packages\cv2
+mkdir "%CV2%"
+echo BINARIES_PATHS = [r"%SBBIN%"] + BINARIES_PATHS> "%CV2%\config.py"
+echo PYTHON_EXTENSIONS_PATHS = [r'''%VIRTUAL_ENV%\lib\site-packages\cv2\python-3.8'''] + PYTHON_EXTENSIONS_PATHS> "%CV2%\config-3.8.py"
 
 cls

--- a/winpostinstall.bat
+++ b/winpostinstall.bat
@@ -1,14 +1,15 @@
 set ODMBASE=%~dp0
 set VIRTUAL_ENV=%ODMBASE%venv
-set PYENVCFG=%VIRTUAL_ENV%\pyvenv.cfg
-set SBBIN=%ODMBASE%SuperBuild\install\bin
+IF "%~1"=="" (set WRITABLE_VIRTUAL_ENV=%VIRTUAL_ENV%) ELSE (set WRITABLE_VIRTUAL_ENV=%~1)
 
 rem Hot-patching pyvenv.cfg
-echo home = %ODMBASE%venv\Scripts> "%PYENVCFG%"
+set PYENVCFG=%WRITABLE_VIRTUAL_ENV%\pyvenv.cfg
+echo home = %VIRTUAL_ENV%\Scripts> "%PYENVCFG%"
 echo include-system-site-packages = false>> "%PYENVCFG%"
 
 rem Hot-patching cv2 extension configs
-echo BINARIES_PATHS = [r"%SBBIN%"] + BINARIES_PATHS> venv\Lib\site-packages\cv2\config.py
-echo PYTHON_EXTENSIONS_PATHS = [r'''%VIRTUAL_ENV%\lib\site-packages\cv2\python-3.8'''] + PYTHON_EXTENSIONS_PATHS> venv\Lib\site-packages\cv2\config-3.8.py
+set SBBIN=%ODMBASE%SuperBuild\install\bin
+echo BINARIES_PATHS = [r"%SBBIN%"] + BINARIES_PATHS> "%WRITABLE_VIRTUAL_ENV%\Lib\site-packages\cv2\config.py"
+echo PYTHON_EXTENSIONS_PATHS = [r'''%VIRTUAL_ENV%\lib\site-packages\cv2\python-3.8'''] + PYTHON_EXTENSIONS_PATHS> "%WRITABLE_VIRTUAL_ENV%\Lib\site-packages\cv2\config-3.8.py"
 
 cls


### PR DESCRIPTION
This is required for packaging ODM in a MSIX package, which are deployed to a read-only location. PSF can redirect writes to the package root to a writeable overlay directory to compensate for that.

PSF also supports start scripts so we can run `winpostinstall.bat` to patch up the path to where ODM is installed (usually under `C:\Program Files\WindowsApps`, but this can be changed). However those don't run under the FileRedirectionFixup, so we need to manually write to the overlay directory so that Python picks them up with the FileRedirectionFixup later.