### PR TITLE
windows setup creation error

### DIFF
--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
Hello, 
the version 3.5.6 version setup didn't created as i see. The error says windows-2019 is deprecated.
<img width="1416" height="186" alt="image" src="https://github.com/user-attachments/assets/39c40791-28ea-4dc3-a79f-ca3852031660" />

I changed to windows-2022.