### PR TITLE
Bump pygltflib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ xmltodict==0.12.0
 fpdf2==2.4.6
 Shapely==1.7.1
 onnxruntime==1.12.1
-pygltflib==1.15.3
+pygltflib==1.16.5
 codem==0.24.0
 trimesh==3.17.1
 pandas==1.5.2


### PR DESCRIPTION
When rebuilding the dev environment I've been getting:

```
root@8f5961b43124:/var/www# python3 /usr/local/lib/python3.9/dist-packages/pygltflib/extensions/__init__.py 
  File "/usr/local/lib/python3.9/dist-packages/pygltflib/extensions/__init__.py", line 7
    "bufferView": 5,
    ^
SyntaxError: illegal target for annotation
```

Which is a known bug in pygltflib which has been fixed with a newer release. 