### PR TITLE
add forward option to retain las file scale and offset

### DIFF
--- a/opendm/dem/pdal.py
+++ b/opendm/dem/pdal.py
@@ -164,6 +164,7 @@ def run_pdaltranslate_smrf(fin, fout, scalar, slope, threshold, window):
         '--filters.smrf.slope=%s' % slope,
         '--filters.smrf.threshold=%s' % threshold,
         '--filters.smrf.window=%s' % window,
+        '--writers.las.forward=scale,offset'
     ]
 
     system.run(' '.join(cmd))


### PR DESCRIPTION
When creating the georeferenced laz file, the scale is set to 0.001m(or value of spacing if it's smaller), offset is set to origin of the dataset. But the following classification steps do not respect the scale and offset, using the default value of pdal instead, which restricts the precision of point cloud data to 0.01m. 

Fixed the smrf filter that used pdal directly. Still working on fixing OpenPointClass
