### PR TITLE
Add flag `--merge-skip-blending` to skip expensive blending steps during splitmerge workflow

### DIFF
--- a/contrib/mergepreview/mergepreview.py
+++ b/contrib/mergepreview/mergepreview.py
@@ -116,7 +116,7 @@ if len(all_orthos_and_ortho_cuts) > 1:
         'BIGTIFF': 'IF_SAFER',
         'BLOCKXSIZE': 512,
         'BLOCKYSIZE': 512
-    })
+    }, args.merge_skip_blending)
 
 
     log.ODM_INFO("Wrote %s" % output_file)

--- a/opendm/config.py
+++ b/opendm/config.py
@@ -828,6 +828,18 @@ def config(argv=None, parser=None):
                           'Options: %(choices)s. Default: '
                             '%(default)s'))
 
+    # TODO ideally the blending should be optimised so we don't need this param to skip it, e.g.
+    #   1. Only blend in a buffer zone around cutline edges (e.g., 100-200 pixels)
+    #   2. Skip blending for interior regions that are far from edges
+    #   3. This would require detecting which blocks intersect cutline boundaries
+    # We have block-based processing already in place in orthophoto.py, so need logic to determine
+    # if a block needs blending based on its proximity to cutlines
+    parser.add_argument('--merge-skip-blending',
+                        action=StoreTrue,
+                        nargs=0,
+                        default=False,
+                        help='During the orthophoto merging, skip expensive blending operation: %(default)s')
+
     parser.add_argument('--force-gps',
                     action=StoreTrue,
                     nargs=0,

--- a/stages/splitmerge.py
+++ b/stages/splitmerge.py
@@ -262,7 +262,7 @@ class ODMMergeStage(types.ODM_Stage):
                             os.remove(tree.odm_orthophoto_tif)
 
                         orthophoto_vars = orthophoto.get_orthophoto_vars(args)
-                        orthophoto.merge(all_orthos_and_ortho_cuts, tree.odm_orthophoto_tif, orthophoto_vars)
+                        orthophoto.merge(all_orthos_and_ortho_cuts, tree.odm_orthophoto_tif, orthophoto_vars, args.merge_skip_blending)
                         orthophoto.post_orthophoto_steps(args, merged_bounds_file, tree.odm_orthophoto_tif, tree.orthophoto_tiles, args.orthophoto_resolution,
                             reconstruction, tree, False)
                     elif len(all_orthos_and_ortho_cuts) == 1:


### PR DESCRIPTION
- On request from @smathermather, after using splitmerge on a large 80km2 area of imagery in Freetown.
- If used, the flag skips step 2 and 3 of blending, during ortho production, as the step is slower than all the other processing 'by some factors'.
- This is likely a temporary solution - added a note to the code about this:

```python
    # Ideally the blending should be optimised so we don't need this param to skip it, e.g.
    #   1. Only blend in a buffer zone around cutline edges (e.g., 100-200 pixels)
    #   2. Skip blending for interior regions that are far from edges
    #   3. This would require detecting which blocks intersect cutline boundaries
    # We have block-based processing already in place in orthophoto.py, so need logic to determine
    # if a block needs blending based on its proximity to cutlines
```