### PR TITLE
Improve camera identification

### DIFF
--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -174,6 +174,9 @@ class ODM_Photo:
         self.camera_projection = 'brown'
         self.focal_ratio = 0.85
 
+        # Sensor identifier
+        self.serial_number = 'unknown'
+
         # parse values from metadata
         self.parse_exif_values(path_file)
 
@@ -300,7 +303,12 @@ class ODM_Photo:
                    'EXIF ExifImageLength' in tags:
                    self.exif_width = self.int_value(tags['EXIF ExifImageWidth'])
                    self.exif_height = self.int_value(tags['EXIF ExifImageLength'])
-                
+
+                if 'EXIF LensSerialNumber' in tags:
+                    self.serial_number = tags['EXIF LensSerialNumber'].values if tags['EXIF LensSerialNumber'].values else 'unknown'
+                elif 'EXIF BodySerialNumber' in tags:
+                    self.serial_number = tags['EXIF BodySerialNumber'].values if tags['EXIF BodySerialNumber'].values else 'unknown'
+                    
             except Exception as e:
                 log.ODM_WARNING("Cannot read extended EXIF tags for %s: %s" % (self.filename, str(e)))
 
@@ -477,6 +485,9 @@ class ODM_Photo:
                     
                         if self.camera_make.lower() == 'sensefly':
                             self.roll *= -1
+
+                    # Serial number
+                    self.set_attr_from_xmp_tag('serial_number', xtags, ['@drone-dji:CameraSerialNumber', '@drone-dji:DroneSerialNumber'], str)
 
                 except Exception as e:
                     log.ODM_WARNING("Cannot read XMP tags for %s: %s" % (self.filename, str(e)))
@@ -818,6 +829,7 @@ class ODM_Photo:
                     str(int(self.height)),
                     self.camera_projection,
                     str(float(self.focal_ratio))[:6],
+                    self.serial_number.strip()
                 ]
             ).lower()
 


### PR DESCRIPTION
Currently the camera id is created by combining camera make, camera model, width, height, projection type, focal length. However, this is not enough to cover the case when there are two or more drones with the same model and the same capture settings, this can happen on a large survey project where one drone's battery is not enough to cover the whole survey. And if not separating data from multiple drones, a single camera model will be used to optimize across all the images, leading worse accuracy. 

This PR tries to solve this issue by utilizing serial number exists mostly in the drone image metadata. It will attach the serial number at the end of the camera id. Since there could be multiple tags used to represent the serial number from different drone/camera maker, I don't have enough data to cover all the scenario, my implementation is explained below, please suggest and if any other way to read serial number is missing, let me know. 

The serial number will be `unknown` by default, then, when loading metadata, the following exif and xmp tags will be used with the priority in ascending order, camera/len serial number should always be preferred over drone/body serial number, as some drones allow to change sensors. `EXIF BodySerialNumber`, `EXIF LensSerialNumber`, `@drone-dji:DroneSerialNumber`, `@drone-dji:CameraSerialNumber`