### PR TITLE
Fix #1949

### DIFF
--- a/snap/snapcraft24.yaml
+++ b/snap/snapcraft24.yaml
@@ -46,6 +46,7 @@ parts:
       - pkg-config
       - pybind11-dev
       - python3-dev
+      - python3-gdal
       - python3-pip
       - python3-setuptools
       - python3-wheel
@@ -62,6 +63,7 @@ parts:
       - proj-data
       - procps
       - python3
+      - python3-gdal
       - python3-pkg-resources # required base package for core20
       - python3-requests # required base package for core20
       - python3-setuptools


### PR DESCRIPTION
Install python3-gdal. Although this will be overwritten by the pip-installed version, installing it allows the pip-installed version to succeed by installing required dependencies.

Hopefully this will fix #1949.