### PR TITLE
fix(photo): handle special case for Mavic 3E backward-facing images

### DIFF
--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -471,6 +471,15 @@ class ODM_Photo:
                     # Roll: 0 (assuming gimbal)
                     if self.has_ypr():
                         if self.camera_make.lower() in ['dji', 'hasselblad']:
+                            
+                            # Mavic 3E smart oblique backward-facing images need special treatment
+                            # backward-facing images are identified with a 180º roll
+                            if abs(self.roll) > 90:
+                               # Camera faces opposite direction
+                                self.yaw = (self.yaw + 180) % 360
+                                # Pitch axis is inverted in flipped frame
+                                self.pitch = -self.pitch
+ 
                             self.pitch = 90 + self.pitch
                     
                         if self.camera_make.lower() == 'sensefly':


### PR DESCRIPTION
DJI Mavic 3 Enterprise has an unintuitive method for recording gimbal angles when rolled past nadir in the backward direction. 

All pitch angles are less than or equal to zero, with zero being nadir. When the gimbal physically rolls past nadir, images are recorded upside-down, roll is recorded as 180, gimbal heading is turned 180º, and pitch is nadir (0) - angle (pitch is consistent with forward gimbal. 

Tested and works with a Mavic 3E. 