### PR TITLE
Fix image_groups.txt nested recursion issue

### DIFF
--- a/opendm/osfm.py
+++ b/opendm/osfm.py
@@ -657,7 +657,7 @@ def get_submodel_argv(args, submodels_path = None, submodel_name = None):
         reading the contents of --boundary
     """
     assure_always = ['orthophoto_cutline', 'dem_euclidean_map', 'skip_3dmodel', 'skip_report']
-    remove_always = ['split', 'split_overlap', 'rerun_from', 'rerun', 'gcp', 'end_with', 'sm_cluster', 'rerun_all', 'pc_csv', 'pc_las', 'pc_ept', 'tiles', 'copy-to', 'cog']
+    remove_always = ['split', 'split_overlap', 'split_image_groups', 'rerun_from', 'rerun', 'gcp', 'end_with', 'sm_cluster', 'rerun_all', 'pc_csv', 'pc_las', 'pc_ept', 'tiles', 'copy_to', 'cog']
     read_json_always = ['cameras', 'boundary']
 
     argv = sys.argv

--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -471,6 +471,15 @@ class ODM_Photo:
                     # Roll: 0 (assuming gimbal)
                     if self.has_ypr():
                         if self.camera_make.lower() in ['dji', 'hasselblad']:
+                            
+                            # Mavic 3E smart oblique backward-facing images need special treatment
+                            # backward-facing images are identified with a 180º roll
+                            if abs(self.roll) > 90:
+                               # Camera faces opposite direction
+                                self.yaw = (self.yaw + 180) % 360
+                                # Pitch axis is inverted in flipped frame
+                                self.pitch = -self.pitch
+ 
                             self.pitch = 90 + self.pitch
                     
                         if self.camera_make.lower() == 'sensefly':


### PR DESCRIPTION
Split dataset with image_groups.txt solves the first submodel in a nested loop due to a missing exclude tag, split_image_groups. 

