### PR TITLE
Fix camera angle(omega,phi,kappa) calculation

### DIFF
--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -931,7 +931,14 @@ class ODM_Photo:
             # Unit vector pointing north
             xnp /= m
 
-            znp = np.array([0, 0, -1]).T
+            # znp is aproximately p1 but perpendicular xnp
+            znp = p1
+            znp -= znp.dot(xnp) * xnp
+            m = np.linalg.norm(znp)
+            if m == 0:
+                log.ODM_WARNING("Cannot compute OPK angles, divider = 0")
+                return
+            znp /= m
             ynp = np.cross(znp, xnp)
 
             cen = np.array([xnp, ynp, znp]).T


### PR DESCRIPTION
This should be a bug in camera angle calculation, leading to bad performance in triangulation reconstruction method. 
The issue is discussed here. I'm not 100% sure if the fix meets the goal of the original design, but at least the fix would make it mathematically correct. Wish to get some input for this. 
https://github.com/mapillary/OpenSfM/issues/1098 