### PR TITLE
Allow disabling the custom pycache location

### DIFF
--- a/win32env.bat
+++ b/win32env.bat
@@ -15,7 +15,7 @@ set GDAL_DRIVER_PATH=%GDALBASE%\gdalplugins
 set OSFMBASE=%ODMBASE%SuperBuild\install\bin\opensfm\bin
 set SBBIN=%ODMBASE%SuperBuild\install\bin
 set PDAL_DRIVER_PATH=%ODMBASE%SuperBuild\install\bin
-set PYTHONPYCACHEPREFIX=%PROGRAMDATA%\ODM\pycache
+if not defined ODMDONTSETPYCACHE set PYTHONPYCACHEPREFIX=%PROGRAMDATA%\ODM\pycache
 
 set PATH=%GDALBASE%;%SBBIN%;%OSFMBASE%
 set PROJ_LIB=%GDALBASE%\data\proj


### PR DESCRIPTION
The MSIX Package Support Framework's file redirection wasn't working properly for ProgramData for some reason, leading to leftover files after uninstall, which is against MS Store policies. By allowing the desktop app to disable the custom pycache, the PSF's package root file redirection is able to work properly instead, storing \_\_pycache\_\_ folders in the per-app location that is cleaned on uninstall.