### PR TITLE
Installing python dependencies last

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -131,9 +131,16 @@ installreqs() {
 
     # edt requires numpy to build
     venv/bin/pip install numpy==2.3.2
+    set +e
+}
+
+installpython() {
+    echo "Installing Python requirements with compiled GDAL"
+    cd /code
+    export GDAL_CONFIG=${RUNPATH}/SuperBuild/install/bin/gdal-config
+    
+    set -e
     venv/bin/pip install -r requirements.txt --ignore-installed
-    #if [ ! -z "$GPU_INSTALL" ]; then
-    #fi
     set +e
 }
     
@@ -163,9 +170,11 @@ install() {
         -DPython_FIND_VIRTUALENV=ONLY \
         && make -j$processes
 
+    installpython
+
     echo "Configuration Finished"
 }
-
+ 
 uninstall() {
     check_version
 
@@ -196,18 +205,20 @@ clean() {
 
 usage() {
     echo "Usage:"
-    echo "bash configure.sh <install|update|uninstall|installreqs|help> [nproc]"
+    echo "bash configure.sh <install|update|uninstall|installreqs|installpython|help> [nproc]"
     echo "Subcommands:"
     echo "  install"
     echo "    Installs all dependencies and modules for running OpenDroneMap"
     echo "  installruntimedepsonly"
     echo "    Installs *only* the runtime libraries (used by docker builds). To build from source, use the 'install' command."
+    echo "  installreqs"
+    echo "    Only installs the system requirements and dependencies (does not build SuperBuild or install Python packages)"
+    echo "  installpython"
+    echo "    Installs Python requirements after SuperBuild is compiled"
     echo "  reinstall"
     echo "    Removes SuperBuild and build modules, then re-installs them. Note this does not update OpenDroneMap to the latest version. "
     echo "  uninstall"
     echo "    Removes SuperBuild and build modules. Does not uninstall dependencies"
-    echo "  installreqs"
-    echo "    Only installs the requirements (does not build SuperBuild)"
     echo "  clean"
     echo "    Cleans the SuperBuild directory by removing temporary files. "
     echo "  help"
@@ -215,7 +226,7 @@ usage() {
     echo "[nproc] is an optional argument that can set the number of processes for the make -j tag. By default it uses $(nproc)"
 }
 
-if [[ $1 =~ ^(install|installruntimedepsonly|reinstall|uninstall|installreqs|clean)$ ]]; then
+if [[ $1 =~ ^(install|installruntimedepsonly|reinstall|uninstall|installreqs|installpython|clean)$ ]]; then
     RUNPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
     "$1"
 else

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -139,7 +139,8 @@ parts:
       - python3-setuptools
       - swig
     stage-packages:      
-      - libcurl3t64-gnutls      - libgeotiff5
+      - libcurl3t64-gnutls      
+      - libgeotiff5
       - libjsoncpp1
       - libspqr2
       - proj-data

--- a/snap/snapcraft24.yaml
+++ b/snap/snapcraft24.yaml
@@ -133,6 +133,8 @@ parts:
     source: .
     plugin: nil
     build-packages:
+      - libexpat-dev
+      - libgeos-dev
       - libgeotiff-dev
       - libhdf5-serial-dev
       - libopenmpi-dev
@@ -145,7 +147,9 @@ parts:
       - libaec0
       - libcurl3t64-gnutls
       - libcurl4t64
+      - libexpat1
       - libgeotiff5
+      - libgeos-c1t64
       - libhdf5-103-1t64
       - libjsoncpp25
       - libspqr4


### PR DESCRIPTION
Python dependencies (throug PIP) require gdal, moving python install after superbuild. Keeping Numpy (to compile opnecv).