### PR TITLE
Add Azure Artifact Signing support

### DIFF
--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     runs-on: windows-2022
+    environment: azuresigning
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -26,12 +27,6 @@ jobs:
       uses: jwlawson/actions-setup-cmake@v1.13
       with:
         cmake-version: '3.24.x'
-    - name: Extract code signing cert
-      id: code_sign
-      uses: timheuer/base64-to-file@v1
-      with:
-        fileName: 'comodo.pfx'
-        encodedString: ${{ secrets.CODE_SIGNING_CERT }}
     - name: Install venv
       run: |
         python -m pip install virtualenv
@@ -43,11 +38,20 @@ jobs:
         rmdir SuperBuild\download /s /q
         rmdir SuperBuild\build /s /q
       shell: cmd
-    - name: Create setup
-      env: 
-        CODE_SIGN_CERT_PATH: ${{ steps.code_sign.outputs.filePath }}
+    - name: Retrieve the metadata and decode it to a file
+      env:
+        CERTIFICATE_BASE64: ${{ secrets.AZURESIGNING_METADATA }}
       run: |
-        python configure.py dist --code-sign-cert-path $env:CODE_SIGN_CERT_PATH
+        echo $AZURESIGNING_METADATA | base64 --decode > metadata.json
+    - name: Azure login
+      uses: azure/login@v1
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - name: Create setup
+      run: |
+        python configure.py dist --azure-signing-metadata metadata.json
     - name: Upload Setup File
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -42,7 +42,8 @@ jobs:
       env:
         CERTIFICATE_BASE64: ${{ secrets.AZURESIGNING_METADATA }}
       run: |
-        echo $AZURESIGNING_METADATA | base64 --decode > metadata.json
+        echo $AZURESIGNING_METADATA | base64 --decode > "$RUNNER_TEMP\metadata.json"
+      shell: bash
     - name: Azure login
       uses: azure/login@v1
       with:
@@ -51,7 +52,8 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     - name: Create setup
       run: |
-        python configure.py dist --azure-signing-metadata metadata.json
+        python configure.py dist --azure-signing-metadata "%RUNNER_TEMP%\metadata.json"
+      shell: cmd
     - name: Upload Setup File
       uses: actions/upload-artifact@v4
       with:

--- a/configure.py
+++ b/configure.py
@@ -34,6 +34,11 @@ parser.add_argument('--code-sign-cert-path',
                     default='',
                     required=False,
                     help='Path to pfx code signing certificate')
+parser.add_argument('--azure-signing-metadata',
+                    type=str,
+                    default='',
+                    required=False,
+                    help='Path to Azure Artifact Signing metadata file')
 
 args = parser.parse_args()
 
@@ -178,6 +183,21 @@ def dist():
         with urllib.request.urlopen(signtool_url) as response, open(signtool_path, 'wb') as out_file:
             shutil.copyfileobj(response, out_file)
 
+    # Download Artifact Signing Dlib
+    if args.azure_signing_metadata:
+        azure_signing_path = os.path.join("SuperBuild", "download", "microsoft.artifactsigning.client.1.0.115.nupkg")
+        azure_signing_url = "https://www.nuget.org/api/v2/package/Microsoft.ArtifactSigning.Client/1.0.115"
+        if not os.path.exists(azure_signing_path):
+            print("Downloading %s" % azure_signing_url)
+            with urllib.request.urlopen(azure_signing_url) as response, open(azure_signing_path, 'wb') as out_file:
+                shutil.copyfileobj(response, out_file)
+
+        os.mkdir("azuresigning")
+
+        print("Extracting --> azuresigning/")
+        with zipfile.ZipFile(azure_signing_path) as z:
+            z.extractall("azuresigning")
+
     # Download innosetup
     if not os.path.isdir("innosetup"):
         innosetupzip_path = os.path.join("SuperBuild", "download", "innosetup.zip")
@@ -195,8 +215,11 @@ def dist():
 
     # Run
     cs_flags = '/DSKIP_SIGN=1'
-    if args.code_sign_cert_path:
-        cs_flags = '"/Ssigntool=%s sign /f %s /fd SHA1 /t http://timestamp.sectigo.com $f"' % (signtool_path, args.code_sign_cert_path)
+    if args.azure_signing_metadata:
+        dlib_path = os.path.join("azuresigning", "bin", "x86", "Azure.CodeSigning.Dlib.dll")
+        cs_flags = '"/Ssigntool=$q%s$q sign /v /debug /fd SHA256 /tr http://timestamp.acs.microsoft.com /td SHA256 /dlib $q%s$q /dmdf $q%s$q $f"' % (os.path.abspath(signtool_path), os.path.abspath(dlib_path), args.azure_signing_metadata)
+    else if args.code_sign_cert_path:
+        cs_flags = '"/Ssigntool=$q%s$q sign /f $q%s$q /fd SHA1 /t http://timestamp.sectigo.com $f"' % (os.path.abspath(signtool_path), args.code_sign_cert_path)
     run("innosetup\\iscc /Qp " + cs_flags  + " \"innosetup.iss\"")
 
     print("Done! Setup created in dist/")

--- a/configure.py
+++ b/configure.py
@@ -218,7 +218,7 @@ def dist():
     if args.azure_signing_metadata:
         dlib_path = os.path.join("azuresigning", "bin", "x86", "Azure.CodeSigning.Dlib.dll")
         cs_flags = '"/Ssigntool=$q%s$q sign /v /debug /fd SHA256 /tr http://timestamp.acs.microsoft.com /td SHA256 /dlib $q%s$q /dmdf $q%s$q $f"' % (os.path.abspath(signtool_path), os.path.abspath(dlib_path), args.azure_signing_metadata)
-    else if args.code_sign_cert_path:
+    elif args.code_sign_cert_path:
         cs_flags = '"/Ssigntool=$q%s$q sign /f $q%s$q /fd SHA1 /t http://timestamp.sectigo.com $f"' % (os.path.abspath(signtool_path), args.code_sign_cert_path)
     run("innosetup\\iscc /Qp " + cs_flags  + " \"innosetup.iss\"")
 


### PR DESCRIPTION
This should work, in theory. Not tested because I do not have the setup for GitHub Actions auth to Azure on my side.

Before this PR is merged, it requires adding a new secret beyond the existing ones: AZURESIGNING_METADATA, which contains a base64 encoded version of the Artifact Signing metadata.json file. See [here](https://learn.microsoft.com/en-us/azure/artifact-signing/how-to-signing-integrations#create-a-json-file) for how to create such a file.