### PR TITLE
Add id-token write permission required for the Azure Login action to get an OIDC token

### DIFF
--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -7,6 +7,10 @@ on:
     tags:
     - v*
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     runs-on: windows-2022


### PR DESCRIPTION
Should fix the error currently seen in Actions.