### PR TITLE
Fix wrong environment variable name

### DIFF
--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -44,7 +44,7 @@ jobs:
       shell: cmd
     - name: Retrieve the metadata and decode it to a file
       env:
-        CERTIFICATE_BASE64: ${{ secrets.AZURESIGNING_METADATA }}
+        AZURESIGNING_METADATA: ${{ secrets.AZURESIGNING_METADATA }}
       run: |
         echo $AZURESIGNING_METADATA | base64 --decode > "$RUNNER_TEMP\metadata.json"
       shell: bash


### PR DESCRIPTION
The previous commit got all the way to the signing step, but failed to sign because the metadata.json file contained nothing. Oops.