### PR TITLE
Use copy of signtool from GH runner

### DIFF
--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -56,7 +56,7 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     - name: Create setup
       run: |
-        python configure.py dist --azure-signing-metadata "%RUNNER_TEMP%\metadata.json"
+        python configure.py dist --signtool-path "C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe" --azure-signing-metadata "%RUNNER_TEMP%\metadata.json"
       shell: cmd
     - name: Upload Setup File
       uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,5 @@ venv/
 python312/
 dist/
 innosetup/
+azuresigning/
 .DS_Store

--- a/configure.py
+++ b/configure.py
@@ -29,6 +29,11 @@ parser.add_argument('--vcpkg-archive-url',
                     default='https://github.com/OpenDroneMap/windows-deps/releases/download/2.6.0/vcpkg-export.zip',
                     required=False,
                     help='Path to VCPKG export archive')
+parser.add_argument('--signtool-path',
+                    type=str,
+                    default='',
+                    required=False,
+                    help='Path to x64 signtool.exe')
 parser.add_argument('--code-sign-cert-path',
                     type=str,
                     default='',
@@ -175,14 +180,6 @@ def dist():
         with zipfile.ZipFile(pythonzip_path) as z:
             z.extractall("python312")
 
-    # Download signtool
-    signtool_path = os.path.join("SuperBuild", "download", "signtool.exe")
-    signtool_url = "https://github.com/OpenDroneMap/windows-deps/releases/download/2.5.0/signtool.exe"
-    if not os.path.exists(signtool_path):
-        print("Downloading %s" % signtool_url)
-        with urllib.request.urlopen(signtool_url) as response, open(signtool_path, 'wb') as out_file:
-            shutil.copyfileobj(response, out_file)
-
     # Download Artifact Signing Dlib
     if args.azure_signing_metadata:
         azure_signing_path = os.path.join("SuperBuild", "download", "microsoft.artifactsigning.client.1.0.115.nupkg")
@@ -215,11 +212,12 @@ def dist():
 
     # Run
     cs_flags = '/DSKIP_SIGN=1'
-    if args.azure_signing_metadata:
-        dlib_path = os.path.join("azuresigning", "bin", "x86", "Azure.CodeSigning.Dlib.dll")
-        cs_flags = '"/Ssigntool=$q%s$q sign /v /debug /fd SHA256 /tr http://timestamp.acs.microsoft.com /td SHA256 /dlib $q%s$q /dmdf $q%s$q $f"' % (os.path.abspath(signtool_path), os.path.abspath(dlib_path), args.azure_signing_metadata)
-    elif args.code_sign_cert_path:
-        cs_flags = '"/Ssigntool=$q%s$q sign /f $q%s$q /fd SHA1 /t http://timestamp.sectigo.com $f"' % (os.path.abspath(signtool_path), args.code_sign_cert_path)
+    if args.signtool_path:
+        if args.azure_signing_metadata:
+            dlib_path = os.path.join("azuresigning", "bin", "x64", "Azure.CodeSigning.Dlib.dll")
+            cs_flags = '"/Ssigntool=$q%s$q sign /v /debug /fd SHA256 /tr http://timestamp.acs.microsoft.com /td SHA256 /dlib $q%s$q /dmdf $q%s$q $f"' % (os.path.abspath(args.signtool_path), os.path.abspath(dlib_path), args.azure_signing_metadata)
+        elif args.code_sign_cert_path:
+            cs_flags = '"/Ssigntool=$q%s$q sign /f $q%s$q /fd SHA1 /t http://timestamp.sectigo.com $f"' % (os.path.abspath(args.signtool_path), args.code_sign_cert_path)
     run("innosetup\\iscc /Qp " + cs_flags  + " \"innosetup.iss\"")
 
     print("Done! Setup created in dist/")


### PR DESCRIPTION
Signing was failing because the copy of signtool was too out of date. The GitHub runner includes a newer copy, so update the script to use that