### PR TITLE
Fix GPU pipeline failure in Kubernetes/GKE (libcuda.so.1 and nvidia-smi PATH)

### DIFF
--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -30,6 +30,8 @@ FROM nvidia/cuda:12.9.1-runtime-ubuntu24.04
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/local/lib/python3.12/dist-packages:/code/SuperBuild/install/lib/python3.12/dist-packages:/code/SuperBuild/install/bin/opensfm" \
+    # The following paths (/usr/local/nvidia/lib64 and /usr/local/nvidia/lib) 
+    # are required for compatibility with Google Kubernetes Engine (GKE) managed drivers.
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib:/usr/local/nvidia/lib64:/usr/local/nvidia/lib" \
     PDAL_DRIVER_PATH="/code/SuperBuild/install/bin"
 
@@ -38,6 +40,7 @@ WORKDIR /code
 # Copy everything we built from the builder
 COPY --from=builder /code /code
 
+# Include /usr/local/nvidia/bin in PATH for GKE compatibility
 ENV PATH="/code/venv/bin:/usr/local/nvidia/bin:$PATH"
 
 RUN apt-get update -y \

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -30,7 +30,7 @@ FROM nvidia/cuda:12.9.1-runtime-ubuntu24.04
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/local/lib/python3.12/dist-packages:/code/SuperBuild/install/lib/python3.12/dist-packages:/code/SuperBuild/install/bin/opensfm" \
-    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib" \
+    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/code/SuperBuild/install/lib:/usr/local/nvidia/lib64:/usr/local/nvidia/lib" \
     PDAL_DRIVER_PATH="/code/SuperBuild/install/bin"
 
 WORKDIR /code
@@ -38,7 +38,7 @@ WORKDIR /code
 # Copy everything we built from the builder
 COPY --from=builder /code /code
 
-ENV PATH="/code/venv/bin:$PATH"
+ENV PATH="/code/venv/bin:/usr/local/nvidia/bin:$PATH"
 
 RUN apt-get update -y \
  && apt-get install -y ffmpeg libtbbmalloc2


### PR DESCRIPTION
## Motivation / Context
When running the ODM GPU image in Kubernetes, specifically on GKE with GPU node pools, the pipeline fails because the container cannot locate `nvidia-smi` or `libcuda.so.1`. This happens because the driver binaries and libraries mounted by the Kubernetes device plugin aren't in the default `PATH` or `LD_LIBRARY_PATH`.

This issue surfaced recently because the base NVIDIA image has been changed. Some NVIDIA images have these paths baked in by default, but `nvidia/cuda:12.9.1-runtime-ubuntu24.04` requires them to be set explicitly.

## Changes Made
This PR introduces a minimal update to the GPU Dockerfile to explicitly add the required NVIDIA paths, ensuring the runtime can correctly interface with the underlying GPU drivers.

**Fixes:** #2001

---

### Verification / Proof of Fix

To verify this, I ran a simple test pod requesting a GPU and executing `nvidia-smi`. 

#### Before (Current `opendronemap/odm:gpu`) ❌

```yaml
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
meta
  name: odm-nvidia-smi
spec:
  nodeSelector:
    node_pool: gpu-node-pool
  tolerations:
    - key: "nvidia.com/gpu"
      operator: "Equal"
      value: "present"
      effect: "NoSchedule"
  containers:
    - name: odm-nvidia-smi
      image: opendronemap/odm:gpu
      command: ["sh", "-c"]
      args: ["nvidia-smi"]
      resources:
        limits:
          nvidia.com/gpu: 1
  restartPolicy: Never
EOF
```

**Logs:**
```bash
$ kubectl logs odm-nvidia-smi        
sh: 1: nvidia-smi: not found
```

#### After (Built with PR changes) ✅

```yaml
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
meta
  name: odm-nvidia-smi
spec:
  nodeSelector:
    node_pool: gpu-node-pool
  tolerations:
    - key: "nvidia.com/gpu"
      operator: "Equal"
      value: "present"
      effect: "NoSchedule"
  containers:
    - name: odm-nvidia-smi
      image: $GCP_AR_URL/opendronemap/odm:gpu  # Custom image with this PR's commit
      command: ["sh", "-c"]
      args: ["nvidia-smi"]
      resources:
        limits:
          nvidia.com/gpu: 1
  restartPolicy: Never
EOF
```

**Logs:**
```text
$ kubectl logs odm-nvidia-smi        
Thu Mar 12 09:29:52 2026       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.274.02             Driver Version: 535.274.02   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  Tesla T4                       Off | 00000000:00:04.0 Off |                    0 |
| N/A   37C    P8               9W /  70W |      2MiB / 15360MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
                                                                                         
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
+---------------------------------------------------------------------------------------+
```

I can also confirm that we've got this latest image running end-to-end in our odm tasks.

cc: @spwoodcock @DodgySpaniard 