### PR TITLE
Change permissions to allow write access for contents

### DIFF
--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -8,7 +8,7 @@ on:
     - v*
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
#1999 added granular permissions to grant `id-token: write` (which isn't granted by default). When doing this, I also added `contents: read` because granular permissions overwrite repo-level permissions, and not having it prevented the workflow from cloning its own repo.

However, the `svenstaro/upload-release-action` action requires `contents: write`, which the pipeline no longer had. Change `contents` to `write` (which implies `read`) to fix that.