### PR TITLE
fix: Obj2Tiles support --y-up-to-z-up parameter

### DIFF
--- a/opendm/config.py
+++ b/opendm/config.py
@@ -728,6 +728,12 @@ def config(argv=None, parser=None):
                         default=False,
                         help='Generate OGC 3D Tiles outputs. Default: %(default)s')
 
+    parser.add_argument('--3d-tiles-y-up-to-z-up',
+                        action=StoreTrue,
+                        nargs=0,
+                        default=False,
+                        help='Generate OGC 3D Tiles outputs, Converts Y-up to Z-up. Default: %(default)s')
+
     parser.add_argument('--rolling-shutter',
                     action=StoreTrue,
                     nargs=0,

--- a/opendm/ogctiles.py
+++ b/opendm/ogctiles.py
@@ -11,7 +11,7 @@ from opendm.entwine import build_entwine
 import fiona
 from shapely.geometry import shape
 
-def build_textured_model(input_obj, output_path, reference_lla = None, model_bounds_file=None, rerun=False):
+def build_textured_model(args, input_obj, output_path, reference_lla = None, model_bounds_file=None, rerun=False):
     if not os.path.isfile(input_obj):
         log.ODM_WARNING("No input OBJ file to process")
         return
@@ -64,7 +64,12 @@ def build_textured_model(input_obj, output_path, reference_lla = None, model_bou
             'lon': lon,
             'alt': alt,
         }
-        system.run('Obj2Tiles "{input}" "{output}" --divisions {divisions} --lat {lat} --lon {lon} --alt {alt} '.format(**kwargs))
+        cmd = 'Obj2Tiles "{input}" "{output}" --divisions {divisions} --lat {lat} --lon {lon} --alt {alt} '.format(**kwargs)
+
+        if getattr(args, '3d_tiles_y_up_to_z_up'):
+            cmd += ' --y-up-to-z-up'
+
+        system.run(cmd)
 
     except Exception as e:
         log.ODM_WARNING("Cannot build 3D tiles textured model: %s" % str(e))
@@ -123,7 +128,7 @@ def build_3dtiles(args, tree, reconstruction, rerun=False):
         if not os.path.isfile(input_obj):
             input_obj = os.path.join(tree.odm_25dtexturing, tree.odm_textured_model_obj)
 
-        build_textured_model(input_obj, model_output_path, reference_lla, model_bounds_file, rerun)
+        build_textured_model(args, input_obj, model_output_path, reference_lla, model_bounds_file, rerun)
     else:
         log.ODM_WARNING("OGC 3D Tiles model %s already generated" % model_output_path)
 


### PR DESCRIPTION
fix [Issue#79](https://github.com/OpenDroneMap/Obj2Tiles/issues/79), add Obj2Tiles support --y-up-to-z-up parameter.
Excuse me, I'm not a Python developer. Please help correct the code.