### PR TITLE
Guard exifread 3.x IndexError on empty DJI MakerNote values

### DIFF
--- a/opendm/photo.py
+++ b/opendm/photo.py
@@ -4,7 +4,20 @@ import os
 import math
 
 import exifread
+import exifread.core.exif_header as _exif_hdr
 import numpy as np
+
+# Workaround for exifread 3.x IndexError on empty DJI MakerNote tag values.
+# exifread's ExifHeader._get_printable_for_field does str(values[0]) without
+# guarding for an empty values list.  Monkeypatch until upstream fixes it.
+# See: https://github.com/ianare/exif-py/issues/254
+_orig_get_printable = _exif_hdr.ExifHeader._get_printable_for_field
+def _safe_get_printable(self, *args, **kwargs):
+    try:
+        return _orig_get_printable(self, *args, **kwargs)
+    except IndexError:
+        return ""
+_exif_hdr.ExifHeader._get_printable_for_field = _safe_get_printable
 from six import string_types
 from datetime import datetime, timedelta, timezone
 


### PR DESCRIPTION
## Summary

Monkeypatches `exifread.core.exif_header.ExifHeader._get_printable_for_field` in `opendm/photo.py` to catch `IndexError` raised by ExifRead 3.x when a MakerNote tag has an empty `values` list.

Some DJI drones (confirmed on DJI M3E) emit MakerNote tags where the decoded values list is empty. ExifRead does `str(values[0])` without a length guard, which raises `IndexError` and kills ODM at the dataset stage.

## Root cause

Upstream bug in exifread 3.x (3.0 through at least 3.5.1). Filed upstream: https://github.com/ianare/exif-py/issues/254 — happy to open the one-line fix as a PR there too; the guard is equivalent to `str(values[0]) if values else \"\"`.

## Why a monkeypatch here

- Small (13 lines), no new dependency, no exifread fork/pin.
- Fails closed (`return \"\"`) — same visible behavior as a well-formed empty tag.
- Isolated to ODM's EXIF entry point (`opendm/photo.py`), so it's easy to remove once the exifread release lands. A `TODO`-style comment points back to the upstream issue.

## Validation

Tested end-to-end against a 1385-image DJI M3E survey (Aztec Highway corridor, New Mexico):
- **Without patch** (stock v3.6.0): dataset stage crashes with `IndexError: list index out of range` on the first offending image.
- **With patch**: full pipeline completes through orthophoto generation; EXIF metadata for affected tags is emitted as empty (the same behavior users would see for a legitimately empty tag).

No regression on non-DJI imagery in our local tests (all previous ODM runs continued to work).

## Scope

Single-file change, no new deps, no flags, no public-API changes.

## Affected versions

ExifRead 3.0 → 3.5.1 (at minimum). When upstream ships a fix, this block can be removed.