### PR TITLE
Keep pyvenv.cfg in ODM installer

### DIFF
--- a/innosetup.iss
+++ b/innosetup.iss
@@ -48,7 +48,7 @@ Source: "opendm\*"; DestDir: "{app}\opendm"; Excludes: "__pycache__"; Flags: ign
 Source: "stages\*"; DestDir: "{app}\stages"; Excludes: "__pycache__"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "SuperBuild\install\bin\*"; DestDir: "{app}\SuperBuild\install\bin"; Excludes: "__pycache__"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "SuperBuild\install\lib\python3.12\*"; DestDir: "{app}\SuperBuild\install\lib\python3.12"; Excludes: "__pycache__"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "venv\*"; DestDir: "{app}\venv"; Excludes: "__pycache__,pyvenv.cfg"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "venv\*"; DestDir: "{app}\venv"; Excludes: "__pycache__"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "python312\*"; DestDir: "{app}\venv\Scripts"; Excludes: "__pycache__"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "console.bat"; DestDir: "{app}"; Flags: ignoreversion
 Source: "VERSION"; DestDir: "{app}"; Flags: ignoreversion


### PR DESCRIPTION
This may sound stupid, but it avoids https://github.com/microsoft/MSIX-PackageSupportFramework/issues/269 by keeping a placeholder, allowing Python's `isfile` to work. The contents of the file are then overriden by the version created in `WriteablePackageRoot`.