### PR TITLE
fix: restore Polygon cutline schema for Shapely 2

### DIFF
--- a/opendm/cutline.py
+++ b/opendm/cutline.py
@@ -13,7 +13,7 @@ from skimage.feature import canny
 from skimage.draw import line
 from skimage.graph import route_through_array
 import shapely
-from shapely.geometry import LineString, mapping, shape
+from shapely.geometry import LineString, MultiPolygon, mapping, shape
 from shapely.ops import polygonize, unary_union
 
 def write_raster(data, file):
@@ -30,6 +30,19 @@ def write_raster(data, file):
 
     with rasterio.open(file, 'w', BIGTIFF="IF_SAFER", **profile) as wout:
         wout.write(data, 1)
+
+def largest_polygon(polygons):
+    cutline_union = unary_union(polygons)
+    if isinstance(cutline_union, MultiPolygon):
+        parts = list(cutline_union.geoms)
+    else:
+        parts = [cutline_union]
+
+    largest = parts[0]
+    for p in parts[1:]:
+        if p.area > largest.area:
+            largest = p
+    return largest
 
 def compute_cutline(orthophoto_file, crop_area_file, destination, max_concurrency=1, scale=1):
     if io.file_exists(orthophoto_file) and io.file_exists(crop_area_file):
@@ -140,18 +153,8 @@ def compute_cutline(orthophoto_file, crop_area_file, destination, max_concurrenc
             return
 
         log.ODM_INFO("Merging polygons")
-        cutline_union = unary_union(polygons)
-        if cutline_union.geom_type == 'MultiPolygon':
-            cutline_polygons = list(cutline_union.geoms)
-        else:
-            cutline_polygons = [cutline_union]
-
-        largest_cutline = cutline_polygons[0]
+        largest_cutline = largest_polygon(polygons)
         max_area = largest_cutline.area
-        for p in cutline_polygons:
-            if p.area > max_area:
-                max_area = p.area
-                largest_cutline = p
         
         log.ODM_INFO("Largest cutline found: %s m^2" % max_area)
 

--- a/opendm/cutline.py
+++ b/opendm/cutline.py
@@ -140,9 +140,11 @@ def compute_cutline(orthophoto_file, crop_area_file, destination, max_concurrenc
             return
 
         log.ODM_INFO("Merging polygons")
-        cutline_polygons = unary_union(polygons)
-        if not hasattr(cutline_polygons, '__getitem__'):
-            cutline_polygons = [cutline_polygons]
+        cutline_union = unary_union(polygons)
+        if cutline_union.geom_type == 'MultiPolygon':
+            cutline_polygons = list(cutline_union.geoms)
+        else:
+            cutline_polygons = [cutline_union]
 
         largest_cutline = cutline_polygons[0]
         max_area = largest_cutline.area
@@ -158,7 +160,7 @@ def compute_cutline(orthophoto_file, crop_area_file, destination, max_concurrenc
             'driver': 'GPKG',
             'schema': {
                 'properties': {},
-                'geometry': 'MultiPolygon'
+                'geometry': 'Polygon'
             }
         }
 

--- a/tests/test_cutline.py
+++ b/tests/test_cutline.py
@@ -1,0 +1,51 @@
+import os
+import tempfile
+import unittest
+
+import fiona
+from shapely.geometry import Polygon, mapping
+
+from opendm.cutline import largest_polygon
+
+
+class TestCutline(unittest.TestCase):
+    def test_largest_polygon_from_single_polygon(self):
+        p = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+        largest = largest_polygon([p])
+        self.assertEqual(largest.geom_type, "Polygon")
+        self.assertAlmostEqual(largest.area, 1.0)
+
+    def test_largest_polygon_from_multipolygon_union(self):
+        small = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+        large = Polygon([(0, 0), (3, 0), (3, 2), (0, 2)])
+        largest = largest_polygon([small, large])
+        self.assertEqual(largest.geom_type, "Polygon")
+        self.assertAlmostEqual(largest.area, 6.0)
+
+    def test_polygon_writes_to_gpkg_with_polygon_schema(self):
+        """ Tests that fiona can write our polygon to a GPKG file"""
+
+        geom = largest_polygon([
+            Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+            Polygon([(2, 0), (5, 0), (5, 2), (2, 2)]),
+        ])
+        self.assertEqual(mapping(geom)["type"], "Polygon")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "cutline.gpkg")
+            with fiona.open(
+                path,
+                "w",
+                driver="GPKG",
+                crs="EPSG:4326",
+                schema={"geometry": "Polygon", "properties": {}},
+            ) as sink:
+                sink.write({"geometry": mapping(geom), "properties": {}})
+
+            with fiona.open(path) as src:
+                feature = next(iter(src))
+                self.assertEqual(feature["geometry"]["type"], "Polygon")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cutline.py
+++ b/tests/test_cutline.py
@@ -10,17 +10,22 @@ from opendm.cutline import largest_polygon
 
 class TestCutline(unittest.TestCase):
     def test_largest_polygon_from_single_polygon(self):
-        p = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+        """ Tests that the largest polygon from a single polygon is the polygon itself """
+
+        p = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]) # 1x1 square
         largest = largest_polygon([p])
+
         self.assertEqual(largest.geom_type, "Polygon")
         self.assertAlmostEqual(largest.area, 1.0)
 
     def test_largest_polygon_from_multipolygon_union(self):
-        small = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
-        large = Polygon([(0, 0), (3, 0), (3, 2), (0, 2)])
+        """ Tests that the largest polygon from a multipolygon union is the largest polygon """
+
+        small = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]) # 1x1 square (area = 1)
+        large = Polygon([(0, 0), (3, 0), (3, 2), (0, 2)]) # 3x2 rectangle (area = 6)
         largest = largest_polygon([small, large])
         self.assertEqual(largest.geom_type, "Polygon")
-        self.assertAlmostEqual(largest.area, 6.0)
+        self.assertAlmostEqual(largest.area, 6.0) # matches large polygon
 
     def test_polygon_writes_to_gpkg_with_polygon_schema(self):
         """ Tests that fiona can write our polygon to a GPKG file"""
@@ -31,6 +36,8 @@ class TestCutline(unittest.TestCase):
         ])
         self.assertEqual(mapping(geom)["type"], "Polygon")
 
+        # Write out the polygon to quickly verify that Fiona can still process
+        # our largest polygon.
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, "cutline.gpkg")
             with fiona.open(


### PR DESCRIPTION
Fix split-merge cutline GPKG writes failing under Shapely 2 + Fiona 1.9+.

This came up with running OATS `brighton_split_merge` test:

```
Traceback (most recent call last):
  File "/code/run.py", line 65, in <module>
    retcode = app.execute()
              ^^^^^^^^^^^^^
  File "/code/stages/odm_app.py", line 118, in execute
    raise e
  File "/code/stages/odm_app.py", line 82, in execute
    self.first_stage.run()
  File "/code/opendm/types.py", line 465, in run
    self.next_stage.run(outputs)
  File "/code/opendm/types.py", line 465, in run
    self.next_stage.run(outputs)
  File "/code/opendm/types.py", line 465, in run
    self.next_stage.run(outputs)
  [Previous line repeated 7 more times]
  File "/code/opendm/types.py", line 444, in run
    self.process(self.args, outputs)
  File "/code/stages/odm_orthophoto.py", line 122, in process
    compute_cutline(tree.odm_orthophoto_tif, 
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/opendm/cutline.py", line 170, in compute_cutline
    sink.write({
  File "/code/.pixi/envs/prod/lib/python3.12/site-packages/fiona/collection.py", line 551, in write
    self.writerecords([record])
  File "/code/.pixi/envs/prod/lib/python3.12/site-packages/fiona/collection.py", line 541, in writerecords
    self.session.writerecs(records, self)
  File "fiona/ogrext.pyx", line 1660, in fiona.ogrext.WritingSession.writerecs
fiona.errors.GeometryTypeValidationError: Record's geometry type does not match collection schema's geometry type: 'Polygon' != 'MultiPolygon'
```

The root cause is related to two dependency bumps we did in #1958 - Shapely 2 no longer has `__getitem__` for `MultiPolygon` and so `unary_union` results were written whole instead of picking the largest polygon. Commit 75a1e1f1 only fixed one half of that mismatch by changing the schema to `MultiPolygon` but Fiona 1.9+ still rejects `Polygon` records against a `MultiPolygon` schema.

Note #1958 testing originally hit the opposite mismatch (`MultiPolygon` record vs `Polygon` schema) before 75a1e1f1; this PR fixes both directions by fixing Shapely unpacking and restoring the Polygon schema.