### PR TITLE
Fix "DLL load failed" startup crash when the target machine has a registered Python 3.12

### DIFF
--- a/winpostinstall.bat
+++ b/winpostinstall.bat
@@ -8,6 +8,16 @@ set PYENVCFG=%WRITABLE_VIRTUAL_ENV%\pyvenv.cfg
 echo home = %VIRTUAL_ENV%\Scripts> "%PYENVCFG%"
 echo include-system-site-packages = false>> "%PYENVCFG%"
 
+rem Write python312._pth next to the embedded python.exe to lock down sys.path.
+rem Without it, the "less-pth" embedded python merges registry PythonPath entries
+rem from any system Python 3.12 (e.g. Anaconda), breaking ctypes/DLL loading.
+set PTHFILE=%VIRTUAL_ENV%\Scripts\python312._pth
+echo python312.zip> "%PTHFILE%"
+echo .>> "%PTHFILE%"
+echo ..\..>> "%PTHFILE%"
+echo ..\Lib\site-packages>> "%PTHFILE%"
+echo import site>> "%PTHFILE%"
+
 rem Hot-patching cv2 extension configs
 set SBBIN=%ODMBASE%SuperBuild\install\bin
 set CV2=%WRITABLE_VIRTUAL_ENV%\Lib\site-packages\cv2


### PR DESCRIPTION
The Windows setup ships an embedded Python build with its ._pth file removed (so that pyvenv.cfg is honored). A side effect is that without a ._pth, python.exe falls back to reading
HKLM/HKCU\Software\Python\PythonCore\3.12\PythonPath from the registry and merges those entries into sys.path.

On any end-user machine that has a registered Python 3.12 install (python.org, Anaconda, etc.), the registered Lib/ and DLLs/ directories take part in module resolution, so stdlib extension modules such as _ctypes.pyd get loaded from the foreign install while their dependent DLLs are not on the search path. ODM then crashes on startup with "ImportError: DLL load failed" as soon as opendm.vmem imports ctypes.

Fix: write a python312._pth next to the embedded python.exe during post-install. When a ._pth is present, sys.path is fully defined by the file and both registry entries and PYTHONPATH/PYTHONHOME are ignored. The file lists the embedded stdlib zip, the embed directory itself, the ODM install root and the venv site-packages, which is exactly the set of paths ODM needs.