### PR TITLE
Fix Linux GDAL build and harden Windows publish

### DIFF
--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -11,6 +11,12 @@ permissions:
   contents: write
   id-token: write
 
+# Let a tagged release build run to completion instead of being superseded by a
+# later push to the same ref. Different refs (master vs. a tag) never contend.
+concurrency:
+  group: publish-windows-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: windows-2022
@@ -59,6 +65,7 @@ jobs:
         python configure.py dist --signtool-path "C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe" --azure-signing-metadata "%RUNNER_TEMP%\metadata.json"
       shell: cmd
     - name: Upload Setup File
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: Setup

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,55 @@
+# Releasing ODM
+
+This document describes how a versioned ODM release is produced and how to
+verify that every artifact actually shipped.
+
+## What a release produces
+
+A release is cut by pushing a `v<version>` git tag (e.g. `v3.6.1`). Three
+workflows react to the tag:
+
+| Workflow | File | Artifact | Destination |
+| --- | --- | --- | --- |
+| Publish Windows Setup | `.github/workflows/publish-windows.yml` | `ODM_Setup_<version>.exe` (signed) | Attached to the GitHub Release |
+| Publish Docker and WSL Images | `.github/workflows/publish-docker.yaml` | `opendronemap/odm:<version>` and `:latest` | Docker Hub |
+| Publish Docker GPU Images | `.github/workflows/publish-docker-gpu.yaml` | `opendronemap/odm:gpu` | Docker Hub |
+
+The **only** asset attached to the GitHub Release object is the Windows
+installer. The Docker images are pushed to Docker Hub, not to the release.
+
+The installer filename comes from the `VERSION` file (`ODM_Setup_{VERSION}.exe`
+in `innosetup.iss`), while the Docker image tag comes from the git tag. Both
+must agree, so `VERSION` and the tag have to be bumped together.
+
+## Pre-flight checklist
+
+- [ ] `VERSION` is bumped to the new version on `master`.
+- [ ] The latest `master` run of **Publish Windows Setup** is green and its
+      `Setup` artifact contains an `.exe`. A tag build reuses the same steps, so
+      a green master build is the best predictor that the tagged build will
+      attach the installer.
+- [ ] The latest `master` run of **Publish Docker and WSL Images** is green.
+- [ ] The latest `master` run of **Publish Docker GPU Images** is green.
+
+Do not tag until all three master builds are green. Tagging a broken `master`
+reproduces the broken build against the tag and yields a release with missing
+artifacts.
+
+## Cutting the release
+
+1. Merge the release commit (with the bumped `VERSION`) to `master` and wait for
+   all three publish workflows to go green on that commit.
+2. Create the GitHub Release and its `v<version>` tag pointing at that commit.
+   `svenstaro/upload-release-action` will also create the release if it does not
+   already exist, but creating it up front lets you write the changelog.
+3. The tag push triggers all three workflows again. The Windows build takes
+   ~1h30m; let it finish — do not cancel it, or the installer will not be
+   attached.
+
+## Post-release verification
+
+- [ ] `gh release view v<version> --json assets` lists `ODM_Setup_<version>.exe`.
+- [ ] `docker manifest inspect opendronemap/odm:<version>` succeeds.
+- [ ] `docker manifest inspect opendronemap/odm:gpu` succeeds and `:latest`
+      points at the new version.
+- [ ] All three tag-triggered workflow runs concluded with `success`.

--- a/configure.sh
+++ b/configure.sh
@@ -138,6 +138,10 @@ installpython() {
     echo "Installing Python requirements"
     cd /code
     set -e
+    # Fiona and rasterio build from source and locate GDAL through gdal-config,
+    # which SuperBuild installs under SuperBuild/install/bin.
+    export GDAL_CONFIG="${RUNPATH}/SuperBuild/install/bin/gdal-config"
+    export PATH="${RUNPATH}/SuperBuild/install/bin:$PATH"
     venv/bin/pip install -r requirements.txt --ignore-installed
     set +e
 }


### PR DESCRIPTION
In preparation for a release, I am going through the different builds to try and make them reliable. This PR includes three related fixes that fix the Docker and WSL builds.

- configure.sh: expose the SuperBuild gdal-config so Fiona and rasterio build against the compiled GDAL 3.11.1 instead of failing to find gdal-config on Linux/Docker. (e.g https://github.com/OpenDroneMap/ODM/actions/runs/28655904272)
- publish-windows.yml: upload the installer artifact with if: always() and add a concurrency group so a tagged build is not superseded.
- Add RELEASE.md documenting the release process and artifact checklist.