### PR TITLE
Add OCI image labels carrying git commit SHA to Docker images

### DIFF
--- a/.github/workflows/publish-docker-gpu.yaml
+++ b/.github/workflows/publish-docker-gpu.yaml
@@ -23,6 +23,11 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Compute build metadata
+      id: buildmeta
+      run: |
+        echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+        echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
     - name: Build and push Docker image
       id: docker_build
       uses: docker/build-push-action@v2
@@ -31,6 +36,10 @@ jobs:
         platforms: linux/amd64
         push: true
         no-cache: true
+        build-args: |
+          GIT_COMMIT=${{ github.sha }}
+          BUILD_DATE=${{ steps.buildmeta.outputs.date }}
+          IMAGE_VERSION=${{ steps.buildmeta.outputs.version }}
         tags: opendronemap/odm:gpu
     # Trigger NodeODM build
     - name: Dispatch NodeODM Build Event

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -35,6 +35,11 @@ jobs:
         images: opendronemap/odm
         tag-semver: |
           {{version}}
+    - name: Compute build metadata
+      id: buildmeta
+      run: |
+        echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+        echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
     - name: Build and push Docker image
       id: docker_build
       uses: docker/build-push-action@v2
@@ -43,6 +48,10 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         no-cache: true
+        build-args: |
+          GIT_COMMIT=${{ github.sha }}
+          BUILD_DATE=${{ steps.buildmeta.outputs.date }}
+          IMAGE_VERSION=${{ steps.buildmeta.outputs.version }}
         tags: |
           ${{ steps.docker_meta.outputs.tags }}
           opendronemap/odm:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,14 @@ RUN bash configure.sh clean
 # size of the layers.
 FROM ubuntu:24.04
 
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+ARG IMAGE_VERSION=unknown
+LABEL org.opencontainers.image.revision="$GIT_COMMIT" \
+      org.opencontainers.image.source="https://github.com/OpenDroneMap/ODM" \
+      org.opencontainers.image.version="$IMAGE_VERSION" \
+      org.opencontainers.image.created="$BUILD_DATE"
+
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/local/lib/python3.12/dist-packages:/code/SuperBuild/install/lib/python3.12/dist-packages:/code/SuperBuild/install/bin/opensfm" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,13 @@ ARG IMAGE_VERSION=unknown
 LABEL org.opencontainers.image.revision="$GIT_COMMIT" \
       org.opencontainers.image.source="https://github.com/OpenDroneMap/ODM" \
       org.opencontainers.image.version="$IMAGE_VERSION" \
-      org.opencontainers.image.created="$BUILD_DATE"
+      org.opencontainers.image.created="$BUILD_DATE" \
+      org.opencontainers.image.title="OpenDroneMap" \
+      org.opencontainers.image.description="Command line toolkit for processing aerial drone imagery" \
+      org.opencontainers.image.url="https://www.opendronemap.org" \
+      org.opencontainers.image.documentation="https://docs.opendronemap.org" \
+      org.opencontainers.image.licenses="AGPL-3.0-only" \
+      org.opencontainers.image.vendor="OpenDroneMap"
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -27,6 +27,14 @@ RUN bash configure.sh clean
 # size of the layers.
 FROM nvidia/cuda:12.9.1-runtime-ubuntu24.04
 
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+ARG IMAGE_VERSION=unknown
+LABEL org.opencontainers.image.revision="$GIT_COMMIT" \
+      org.opencontainers.image.source="https://github.com/OpenDroneMap/ODM" \
+      org.opencontainers.image.version="$IMAGE_VERSION" \
+      org.opencontainers.image.created="$BUILD_DATE"
+
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/local/lib/python3.12/dist-packages:/code/SuperBuild/install/lib/python3.12/dist-packages:/code/SuperBuild/install/bin/opensfm" \

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -33,7 +33,13 @@ ARG IMAGE_VERSION=unknown
 LABEL org.opencontainers.image.revision="$GIT_COMMIT" \
       org.opencontainers.image.source="https://github.com/OpenDroneMap/ODM" \
       org.opencontainers.image.version="$IMAGE_VERSION" \
-      org.opencontainers.image.created="$BUILD_DATE"
+      org.opencontainers.image.created="$BUILD_DATE" \
+      org.opencontainers.image.title="OpenDroneMap" \
+      org.opencontainers.image.description="Command line toolkit for processing aerial drone imagery" \
+      org.opencontainers.image.url="https://www.opendronemap.org" \
+      org.opencontainers.image.documentation="https://docs.opendronemap.org" \
+      org.opencontainers.image.licenses="AGPL-3.0-only" \
+      org.opencontainers.image.vendor="OpenDroneMap"
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/portable.Dockerfile
+++ b/portable.Dockerfile
@@ -27,6 +27,14 @@ RUN bash configure.sh clean
 # size of the layers.
 FROM ubuntu:24.04
 
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+ARG IMAGE_VERSION=unknown
+LABEL org.opencontainers.image.revision="$GIT_COMMIT" \
+      org.opencontainers.image.source="https://github.com/OpenDroneMap/ODM" \
+      org.opencontainers.image.version="$IMAGE_VERSION" \
+      org.opencontainers.image.created="$BUILD_DATE"
+
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONPATH="$PYTHONPATH:/code/SuperBuild/install/local/lib/python3.12/dist-packages:/code/SuperBuild/install/lib/python3.12/dist-packages:/code/SuperBuild/install/bin/opensfm" \

--- a/portable.Dockerfile
+++ b/portable.Dockerfile
@@ -33,7 +33,13 @@ ARG IMAGE_VERSION=unknown
 LABEL org.opencontainers.image.revision="$GIT_COMMIT" \
       org.opencontainers.image.source="https://github.com/OpenDroneMap/ODM" \
       org.opencontainers.image.version="$IMAGE_VERSION" \
-      org.opencontainers.image.created="$BUILD_DATE"
+      org.opencontainers.image.created="$BUILD_DATE" \
+      org.opencontainers.image.title="OpenDroneMap" \
+      org.opencontainers.image.description="Command line toolkit for processing aerial drone imagery" \
+      org.opencontainers.image.url="https://www.opendronemap.org" \
+      org.opencontainers.image.documentation="https://docs.opendronemap.org" \
+      org.opencontainers.image.licenses="AGPL-3.0-only" \
+      org.opencontainers.image.vendor="OpenDroneMap"
 
 # Env variables
 ENV DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Declare the [standard OCI labels](https://specs.opencontainers.org/image-spec/annotations/) (revision, source, version, created) in the final image stage of `portable.Dockerfile`, `gpu.Dockerfile` and `Dockerfile` via build args.

These defaulting to unknown as we can't automatically add them from within Docker but we inject the values from the publish workflows so published images can be mapped back to their source commit.

This means the generated docker images will link to the exact version that was built which will make comparisons easier.