### PR TITLE
Add retries to the Docker build

### DIFF
--- a/portable.Dockerfile
+++ b/portable.Dockerfile
@@ -8,6 +8,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # Prepare directories
 WORKDIR /code
 
+# Make apt resilient to transient ports.ubuntu.com mirror failures
+RUN printf 'Acquire::Retries "6";\nAcquire::http::Timeout "30";\n' \
+      > /etc/apt/apt.conf.d/99-retries
+
 # Copy everything
 COPY . ./
 
@@ -39,6 +43,10 @@ WORKDIR /code
 COPY --from=builder /code /code
 
 ENV PATH="/code/venv/bin:$PATH"
+
+# Make apt resilient to transient ports.ubuntu.com mirror failures
+RUN printf 'Acquire::Retries "6";\nAcquire::http::Timeout "30";\n' \
+      > /etc/apt/apt.conf.d/99-retries
 
 # Install shared libraries that we depend on via APT, but *not*
 # the -dev packages to save space!


### PR DESCRIPTION
The arm64 ubuntu apt repo `ports.ubuntu.com` is slow, overloaded, and prone to failing randomly. This adds a retry to the pulls so the build might succeed eventually. Longer term we should introduce caching and even maybe a local mirror. For now this hopefully makes the build more reliable.

https://github.com/OpenDroneMap/ODM/actions/runs/29427714148/job/87400085257