### PR TITLE
Disable scale solving during alignment

### DIFF
--- a/opendm/align.py
+++ b/opendm/align.py
@@ -81,7 +81,17 @@ def compute_alignment_matrix(input_laz, align_file, stats_dir):
             align_file = repr_func(align_file, input_crs)
             to_delete.append(align_file)
 
-        conf = dataclasses.asdict(codem.CodemRunConfig(align_file, input_laz, OUTPUT_DIR=stats_dir))
+        # Both the reconstruction and the alignment file are georeferenced in
+        # metric units, so the scale between them is known to be 1. Solving
+        # for scale adds a degenerate degree of freedom that can derail
+        # registration on feature-poor scenes.
+        conf = dataclasses.asdict(codem.CodemRunConfig(
+            align_file,
+            input_laz,
+            DSM_SOLVE_SCALE=False,
+            ICP_SOLVE_SCALE=False,
+            OUTPUT_DIR=stats_dir,
+        ))
         fnd_obj, aoi_obj = codem.preprocess(conf)
         fnd_obj.prep()
         aoi_obj.prep()


### PR DESCRIPTION
> I apologies in advance for the length of this PR description for what is basically a one line fix. I'm still not familiar with all of this so I wanted to be explicit in case I messed up.

The OATS brighton alignment tests (`--align` with a GeoTIFF and a LAZ reference) have been failing: ODM completes with exit 0 but logs `Cannot compute alignment matrix` / `Alignment will be skipped`, and no `registration.json` is produced.

Bisecting release images against the same dataset I found that the error happened between 3.3.4 and 3.5.1 (relatively large range due to the docker images available, but there weren't too many that touched codem or align).

In 3.0.4 which is the first available image with the `--align` flag, the codem feature matching debug image (opensfm/stats/codem/dsm_feature_matches.png) looked like this:

<img width="1892" height="1117" alt="working_304_2022era" src="https://github.com/user-attachments/assets/37925385-07fd-4f00-aca2-eae7cab0cfe8" />

In latest it looks like this:

<img width="2418" height="1322" alt="failing_latest_freescale" src="https://github.com/user-attachments/assets/42f78621-5822-4571-a2f7-57c97ecb4c7a" />

In [a70e7445](https://github.com/OpenDroneMap/ODM/pull/1754) the default `--feature-type` changed from `sift` to `dspsift`. That doesn't touch the alignment code but it does change the reconstruction, whose DSM is what codem tries to match against the reference.

<img width="2402" height="1314" alt="passing_latest_sift_badscale" src="https://github.com/user-attachments/assets/23da84f3-c1c5-490c-8952-8e431f332063" />

This does fix the test, but rather than stop there, I wanted to understand why it was failing with `dspsift`. As I understand it, the `--align` flag is meant to align a new output with a secondary source - either an old run or even something third party? In the oats case, the brighton dataset has a generated `dsm.tif` and `model.laz` file that we use as the base to align to. These were generated with ~v3.0.2. When these were generated, we almost guarantee a match as we are using the same version to generate both the reference and comparison. However over time the output has drifted (i.e. getting more accurate), but the change to `dspsift` was the final nail where the reconstruction's DSM was different enough that this made it too hard for codem to find correct matches.

If this is the case, switching back to `sift` isn't necessarily the right move, it would just be a fix to the test, not the product. We could just update the datasets generated files, but that would effectively be the same as disabling the test.

Instead I had a look to see if we could make the feature matching more stable. 

One thing that stood out to me is that the 3.5.1 and 3.5.6 releases fail due to a rejected scale being found. This seemed to be caused by bad feature matches. I also noted that the "correct" scale is actually always 1.0. This makes sense when we realise both sides of the match are georeferenced metric data in the same CRS. To test this, I removed the scale as a solving parameter in codem which effectively locked the scale to 1. This removes a degree of freedom from the solver which, in theory, means there might be fewer matches, but the matches should be higher quality.

<img width="2418" height="1322" alt="working_latest_lockedscale" src="https://github.com/user-attachments/assets/750b8962-cef7-427b-8941-121b4d397803" />

Notice that the images are almost exactly the same as the failing case, but the features are matched much better.  This is very similar to the `sift` fix above, but this time the scale is a perfect 1.0 (as we fixed it). The `sift` fix while looking correct, actually had a scale of roughly 0.8 and so would have resized the model/outputs by 20%.

| Version | Alignment | Solved scale |
|---|---|---|
| 3.0.4 | pass | 0.999 |
| 3.3.4 | pass | 0.998 |
| 3.5.1 / 3.5.6 | fail | rejected in coarse (out of 0.67–1.5 band) |
| latest | fail | coarse solved 0.033 |
| latest (sift) | pass | 0.797 |
| this PR | pass | 1.0 (fixed) |

One last thing, the `dsm.tif` in the brighton dataset actually has a different (wrong?) CSM "UTM zone 10N". This didn't seem to affect the bug though it might affect other outputs. The `model.laz` as a CSM of "UTM zone 15N" which I believe is correct but still failed above.

I believe this is the correct fix, but I would appreciate more experienced eyes on it @smathermather.