### PR TITLE
Give PoissonRecon a writable temporary directory

### DIFF
--- a/opendm/mesh.py
+++ b/opendm/mesh.py
@@ -136,6 +136,9 @@ def dem_to_mesh_gridded(inGeotiff, outMesh, maxVertexCount, maxConcurrency=1):
 def screened_poisson_reconstruction(inPointCloud, outMesh, depth = 8, samples = 1, maxVertexCount=100000, pointWeight=4, threads=context.num_cores):
 
     mesh_path, mesh_filename = os.path.split(outMesh)
+    # PoissonRecon otherwise writes out-of-core PR_* files to the caller's
+    # working directory, which may be read-only even when mesh_path is writable.
+    tempdir = os.path.abspath(mesh_path or '.')
     # mesh_path = path/to
     # mesh_filename = odm_mesh.ply
 
@@ -157,6 +160,7 @@ def screened_poisson_reconstruction(inPointCloud, outMesh, depth = 8, samples = 
             'bin': context.poisson_recon_path,
             'outfile': outMeshDirty,
             'infile': inPointCloud,
+            'tempdir': tempdir,
             'depth': depth,
             'samples': samples,
             'pointWeight': pointWeight,
@@ -167,6 +171,7 @@ def screened_poisson_reconstruction(inPointCloud, outMesh, depth = 8, samples = 
         try:
             system.run('"{bin}" --in "{infile}" '
                     '--out "{outfile}" '
+                    '--tempDir "{tempdir}" '
                     '--depth {depth} '
                     '--pointWeight {pointWeight} '
                     '--samplesPerNode {samples} '

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,0 +1,47 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from opendm import mesh
+
+
+class TestMesh(unittest.TestCase):
+    def test_poisson_uses_output_directory_for_temporary_files(self):
+        with tempfile.TemporaryDirectory() as root:
+            mesh_dir = os.path.join(root, "mesh output")
+            os.mkdir(mesh_dir)
+            point_cloud = os.path.join(root, "cloud.ply")
+            output = os.path.join(mesh_dir, "odm_mesh.ply")
+            dirty = os.path.join(mesh_dir, "odm_mesh.dirty.ply")
+            commands = []
+
+            def run(command):
+                commands.append(command)
+                if "--linearFit" in command:
+                    with open(dirty, "wb"):
+                        pass
+
+            with patch.object(mesh.system, "run", side_effect=run):
+                with patch.object(
+                    mesh.context, "poisson_recon_path", "PoissonRecon"
+                ):
+                    with patch.object(
+                        mesh.context,
+                        "omvs_reconstructmesh_path",
+                        "ReconstructMesh",
+                    ):
+                        result = mesh.screened_poisson_reconstruction(
+                            point_cloud, output, threads=3
+                        )
+
+            self.assertEqual(result, output)
+            self.assertEqual(len(commands), 2)
+            self.assertIn(
+                '--tempDir "{}"'.format(os.path.abspath(mesh_dir)),
+                commands[0],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`PoissonRecon` stores its out-of-core `PR_*` scratch files in `--tempDir`, then `$TMPDIR`, then the process working directory. ODM already knows a writable mesh output directory, but did not pass it to PoissonRecon.

This makes an otherwise resumable mesh stage fail when ODM is launched by a service manager with a non-writable working directory (for example `/`). Reducing the Poisson thread count cannot repair that filesystem failure, so every retry fails before `ReconstructMesh` sees a dirty mesh.

## Change

Pass the absolute output-mesh directory to PoissonRecon through its existing `--tempDir` option. This keeps scratch files beside the dirty mesh and leaves the public Python API and retry behavior unchanged.

A focused unit test captures the generated commands and covers a writable output path containing a space.

## Verification

- New regression test passes.
- Full ODM unit suite: 22 passed in a native ODM 3.6.1 environment.
- The failure mode was source-traced to PoissonRecon's `$TMPDIR` / `./` fallback and `mkstemp` use, then independently recovered in a 24,136,575-point run by supplying a writable working directory.

No container-specific behavior or new dependency is introduced.
