### PR TITLE
Fix --build-overviews: add missing space in gdaladdo arguments

### DIFF
--- a/opendm/orthophoto.py
+++ b/opendm/orthophoto.py
@@ -38,7 +38,7 @@ def build_overviews(orthophoto_file):
                 '--config BIGTIFF_OVERVIEW IF_SAFER '
                 '--config COMPRESS_OVERVIEW JPEG '
                 '--config INTERLEAVE_OVERVIEW PIXEL '
-                '--config PHOTOMETRIC_OVERVIEW YCBCR'
+                '--config PHOTOMETRIC_OVERVIEW YCBCR '
                 '{orthophoto} 2 4 8 16'.format(**kwargs))
 
 def generate_png(orthophoto_file, output_file=None, outsize=None):


### PR DESCRIPTION
Adds a missing trailing space to one string literal in `build_overviews()`.

## Problem

Python concatenates adjacent string literals at compile time, so the command built in `opendm/orthophoto.py` came out as:

```
gdaladdo -r average --config BIGTIFF_OVERVIEW IF_SAFER --config COMPRESS_OVERVIEW JPEG \
  --config INTERLEAVE_OVERVIEW PIXEL \
  --config PHOTOMETRIC_OVERVIEW YCBCR/datasets/code/odm_orthophoto/odm_orthophoto.tif 2 4 8 16
```

The orthophoto path is consumed as the value of `--config PHOTOMETRIC_OVERVIEW`, leaving `2` as the first positional argument — so `gdaladdo` tries to open `2` as its input raster and exits non-zero. `system.run` raises `SubprocessException`, and the run aborts at the `odm_orthophoto` stage rather than degrading.

The preceding `INTERLEAVE_OVERVIEW PIXEL ` line already has its trailing space; only the `PHOTOMETRIC_OVERVIEW` line was missing one.

## Affected

Introduced by #1935 ("Add interleave=pixel and photometric=ycbcr for orthophoto overviews by default"). Affects 3.6.0, 3.6.1, and master; 3.5.6 predates the `PHOTOMETRIC_OVERVIEW` line and is unaffected.

Triggered by any georeferenced reconstruction that reaches `post_orthophoto_steps` with `--build-overviews` and without `--cog`. The failure lands at the end of the pipeline, after SfM and MVS have completed.

## Verification

Extracted the concatenated template from `build_overviews()` and formatted it with a sample path, before and after:

```
# before
... --config PHOTOMETRIC_OVERVIEW YCBCR/datasets/code/odm_orthophoto/odm_orthophoto.tif 2 4 8 16

# after
... --config PHOTOMETRIC_OVERVIEW YCBCR /datasets/code/odm_orthophoto/odm_orthophoto.tif 2 4 8 16
```

I have not run a full pipeline against this branch — the check above covers the argument construction, which is the whole of the defect.

## Notes

Reported as #2058, which was closed automatically by the triage bot shortly after it was opened; it has not been fixed on master.

Kept deliberately to one character. If it would be useful, a follow-up could build the `gdaladdo` arguments as a list and `' '.join(...)` them, which would make the separator structural rather than a matter of remembering the trailing space — happy to open that separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
