### PR TITLE
Restore DEPENDS opensfm for PyPopsift GPU module install order.

### DIFF
--- a/SuperBuild/cmake/External-PyPopsift.cmake
+++ b/SuperBuild/cmake/External-PyPopsift.cmake
@@ -5,7 +5,7 @@ find_package(CUDA 7.0)
 
 if(CUDA_FOUND)
     ExternalProject_Add(pypopsift
-        DEPENDS
+        DEPENDS           opensfm
         PREFIX            ${_SB_BINARY_DIR}
         TMP_DIR           ${_SB_BINARY_DIR}/tmp
         STAMP_DIR         ${_SB_BINARY_DIR}/stamp


### PR DESCRIPTION
`opendronemap/odm:gpu` / `gpu-3.6.1` ships `libpopsift` but not `opensfm.pypopsift`, so GPU feature extraction falls back to CPU SIFT:

```text
cannot import name 'pypopsift' from 'opensfm'
Using CPU for extracting SIFT features as texture size is too large or GPU SIFT is not available
```

Same failure reported here but appears to have died:
- https://community.opendronemap.org/t/cannot-import-name-pypopsift-from-opensfm/26715
- https://community.opendronemap.org/t/odm-gpu-acceleration/26711/4

**Cause:** PyPopsift installs into `SuperBuild/install/bin/opensfm/opensfm`, but OpenSfM clones into that same tree. Since the 24.04 merge, `External-PyPopsift.cmake` has an empty `DEPENDS`, so the module can be built and then deleted. v3.5.6 had `DEPENDS opensfm`.

**Fix:** restore that dependency:

```cmake
DEPENDS opensfm
```

**Checks:**
- Stock `gpu-3.6.1`: `from opensfm import pypopsift` fails; `libpopsift` is present.
- Building pypopsift @ the 3.6.1 pin into an existing OpenSfM tree restores the import and `fits_texture(...)`.
- Injecting that module into the GPU image yields `Using GPU for extracting SIFT features` / `feature_type: SIFT_GPU` on a real run.

**AI disclosure:** Per [CONTRIBUTING.md § Use of AI](https://github.com/OpenDroneMap/documents/blob/master/CONTRIBUTING.md#use-of-ai), assistive AI was used for diagnosis and draft text.