### PR TITLE
Revert YCBCR photometric overviews for orthophoto

### DIFF
--- a/opendm/orthophoto.py
+++ b/opendm/orthophoto.py
@@ -37,8 +37,6 @@ def build_overviews(orthophoto_file):
     system.run('gdaladdo -r average '
                 '--config BIGTIFF_OVERVIEW IF_SAFER '
                 '--config COMPRESS_OVERVIEW JPEG '
-                '--config INTERLEAVE_OVERVIEW PIXEL '
-                '--config PHOTOMETRIC_OVERVIEW YCBCR '
                 '{orthophoto} 2 4 8 16'.format(**kwargs))
 
 def generate_png(orthophoto_file, output_file=None, outsize=None):

--- a/opendm/orthophoto.py
+++ b/opendm/orthophoto.py
@@ -13,7 +13,7 @@ from rasterio.mask import mask
 from opendm import io
 from opendm.tiles.tiler import generate_orthophoto_tiles
 from opendm.cogeo import convert_to_cogeo
-from opendm.utils import add_raster_meta_tags
+from opendm.utils import add_raster_meta_tags, double_quote
 from osgeo import gdal
 from osgeo import ogr
 
@@ -31,7 +31,7 @@ def get_orthophoto_vars(args):
 
 def build_overviews(orthophoto_file):
     log.ODM_INFO("Building Overviews")
-    kwargs = {'orthophoto': orthophoto_file}
+    kwargs = {'orthophoto': double_quote(orthophoto_file)}
     
     # Run gdaladdo
     system.run('gdaladdo -r average '


### PR DESCRIPTION
#2059 aimed to fix the `--build-overview` flag but after testing with https://github.com/OpenDroneMap/oats/pull/13 it seems there is another bug which gives the output:

```
ERROR 6: PHOTOMETRIC_OVERVIEW=YCBCR requires a source raster with only 3 bands (RGB)
```

The orthophotos generated by ODM always carry an alpha band, so gdaladdo will always fail with that flag. 

`INTERLEAVE_OVERVIEW=PIXEL` is also already the GDAL default for GeoTIFF overviews and produces byte-identical output.

Reverts the orthophoto half of #1935, restoring the gdaladdo call that worked before it. The COG path is untouched: the COG driver selects YCbCr JPEG and demotes the alpha band to a mask on its own when the orthophoto compression is JPEG.

While I was here, I also fixed a quoting issue which fixes instances where the path has a space in it.