### PR TITLE
Keep reflectance in float32 when estimating irradiance

### DIFF
--- a/opendm/multispectral.py
+++ b/opendm/multispectral.py
@@ -116,7 +116,7 @@ def vignette_map(photo):
 
 def dn_to_reflectance(photo, image, use_sun_sensor=True):
     radiance = dn_to_radiance(photo, image)
-    irradiance = compute_irradiance(photo, use_sun_sensor=use_sun_sensor)
+    irradiance = float(compute_irradiance(photo, use_sun_sensor=use_sun_sensor))
     reflectance = radiance * math.pi / irradiance
     reflectance[reflectance < 0.0] = 0.0
     reflectance[reflectance > 1.0] = 1.0


### PR DESCRIPTION
`compute_irradiance` returns a numpy float64 scalar on the sun sensor estimate path. Since NumPy 2 dropped value-based casting, dividing the float32 radiance by it promotes the reflectance to float64, which OpenSfM then writes with PREDICTOR=2 instead of the floating point predictor. GDAL rejects that combination on 64 bit samples:

```
  RasterioIOError: IMG_0078_1.tif: PREDICTOR=2 is supported on 64 bit
  samples starting with libtiff > 4.3.0.
```

Coercing the irradiance to a plain float keeps the scalar weakly typed, so the reflectance stays float32 as it did before the NumPy 2 upgrade.

Fixes #2064