### PR TITLE
Keep the Windows installer artifact for three days

### DIFF
--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -64,6 +64,7 @@ jobs:
       with:
         name: Setup
         path: dist\*.exe
+        retention-days: 3
     # Silent-install to a path different from the build dir and run the CLI in a
     # shell with no inherited CONDA_PREFIX. This is the real test that the bundled
     # conda env relocates: it fails here if activate.d doesn't honor %CONDA_PREFIX%.


### PR DESCRIPTION
The publish workflow uploads a 233 MB installer on every master push and keeps it for the default 90 days. Release installers are attached to the GitHub Release, so the artifact only matters until the next push. Forty of these copies used the org's 0.5 GB Actions storage allowance several times over.